### PR TITLE
refactor: tighten nyc-geo-toolkit compatibility checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,9 @@ jobs:
         run: uv run --frozen mkdocs build --strict
 
   tests:
-    name: Test full install (Python ${{ matrix.python-version }}, toolkit ${{ matrix.toolkit-channel }})
+    name:
+      Test full install (Python ${{ matrix.python-version }}, toolkit ${{
+      matrix.toolkit-channel }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -137,8 +139,9 @@ jobs:
       - name: Override nyc-geo-toolkit with main branch
         if: matrix.toolkit-channel == 'main'
         run: >-
-          uv run python -m pip install --upgrade --force-reinstall
-          "nyc-geo-toolkit @ git+https://github.com/random-walks/nyc-geo-toolkit.git@main"
+          uv pip install --python .venv/bin/python --upgrade --force-reinstall
+          "nyc-geo-toolkit @
+          git+https://github.com/random-walks/nyc-geo-toolkit.git@main"
 
       - name: Run full non-live test suite
         run: >-
@@ -150,12 +153,17 @@ jobs:
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name: Test Results (full non-live, Python ${{ matrix.python-version }}, toolkit ${{ matrix.toolkit-channel }})
+          check_name:
+            Test Results (full non-live, Python ${{ matrix.python-version }},
+            toolkit ${{ matrix.toolkit-channel }})
           comment_mode: off
-          files: junit/${{ matrix.toolkit-channel }}-${{ matrix.python-version }}.xml
+          files:
+            junit/${{ matrix.toolkit-channel }}-${{ matrix.python-version }}.xml
 
       - name: Upload coverage report
-        if: matrix.python-version == '3.12' && matrix.toolkit-channel == 'released'
+        if:
+          matrix.python-version == '3.12' && matrix.toolkit-channel ==
+          'released'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         run: uv run --frozen mkdocs build --strict
 
   tests:
-    name: Test full install (Python ${{ matrix.python-version }})
+    name: Test full install (Python ${{ matrix.python-version }}, toolkit ${{ matrix.toolkit-channel }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -113,6 +113,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        toolkit-channel: ["released"]
+        include:
+          - python-version: "3.12"
+            toolkit-channel: "main"
 
     steps:
       - uses: actions/checkout@v6
@@ -130,23 +134,28 @@ jobs:
       - name: Install full test environment
         run: uv sync --frozen --all-extras
 
+      - name: Override nyc-geo-toolkit with main branch
+        if: matrix.toolkit-channel == 'main'
+        run: >-
+          uv run python -m pip install --upgrade --force-reinstall
+          "nyc-geo-toolkit @ git+https://github.com/random-walks/nyc-geo-toolkit.git@main"
+
       - name: Run full non-live test suite
         run: >-
           uv run --frozen pytest -m "not integration" -ra --cov --cov-report=xml
-          --cov-report=term --junitxml="junit/base-${{ matrix.python-version
-          }}.xml" --durations=20
+          --cov-report=term --junitxml="junit/${{ matrix.toolkit-channel }}-${{
+          matrix.python-version }}.xml" --durations=20
 
       - name: Publish test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          check_name:
-            Test Results (full non-live, Python ${{ matrix.python-version }})
+          check_name: Test Results (full non-live, Python ${{ matrix.python-version }}, toolkit ${{ matrix.toolkit-channel }})
           comment_mode: off
-          files: junit/base-${{ matrix.python-version }}.xml
+          files: junit/${{ matrix.toolkit-channel }}-${{ matrix.python-version }}.xml
 
       - name: Upload coverage report
-        if: matrix.python-version == '3.12'
+        if: matrix.python-version == '3.12' && matrix.toolkit-channel == 'released'
         uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/nyc311/geographies/_conversions.py
+++ b/src/nyc311/geographies/_conversions.py
@@ -1,9 +1,15 @@
-"""Conversions for typed boundary collections."""
+"""Compatibility conversions backed by nyc_geo_toolkit."""
 
 from __future__ import annotations
 
-from importlib import import_module
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
+
+from nyc_geo_toolkit import (
+    boundaries_to_dataframe as toolkit_boundaries_to_dataframe,
+)
+from nyc_geo_toolkit import (
+    boundaries_to_geojson as toolkit_boundaries_to_geojson,
+)
 
 from ..models import BoundaryCollection
 
@@ -11,47 +17,18 @@ if TYPE_CHECKING:
     import pandas as pd  # type: ignore[import-untyped]
 
 
-def _require_pandas() -> Any:
+def boundaries_to_geojson(boundaries: BoundaryCollection) -> dict[str, object]:
+    """Convert a typed boundary collection into a GeoJSON FeatureCollection."""
+    return toolkit_boundaries_to_geojson(boundaries)
+
+
+def boundaries_to_dataframe(boundaries: BoundaryCollection) -> pd.DataFrame:
+    """Convert a typed boundary collection into a DataFrame."""
     try:
-        return import_module("pandas")
+        return toolkit_boundaries_to_dataframe(boundaries)
     except ImportError as exc:  # pragma: no cover - exercised in optional tests
         raise ImportError(
             "pandas is required for nyc311 geography dataframe helpers. "
             "Install it with `pip install nyc311[dataframes]`, "
             "`pip install nyc311[science]`, or `pip install pandas`."
         ) from exc
-
-
-def boundaries_to_geojson(boundaries: BoundaryCollection) -> dict[str, object]:
-    """Convert a typed boundary collection into a GeoJSON FeatureCollection."""
-    return {
-        "type": "FeatureCollection",
-        "features": [
-            {
-                "type": "Feature",
-                "properties": {
-                    "geography": feature.geography,
-                    "geography_value": feature.geography_value,
-                    **feature.properties,
-                },
-                "geometry": feature.geometry,
-            }
-            for feature in boundaries.features
-        ],
-    }
-
-
-def boundaries_to_dataframe(boundaries: BoundaryCollection) -> pd.DataFrame:
-    """Convert a typed boundary collection into a DataFrame."""
-    pd = _require_pandas()
-    return pd.DataFrame.from_records(
-        [
-            {
-                "geography": feature.geography,
-                "geography_value": feature.geography_value,
-                **feature.properties,
-                "geometry": feature.geometry,
-            }
-            for feature in boundaries.features
-        ]
-    )

--- a/src/nyc311/geographies/_geojson.py
+++ b/src/nyc311/geographies/_geojson.py
@@ -1,70 +1,14 @@
-"""Parse supported GeoJSON boundary files into nyc311 boundary models."""
+"""Boundary file loading wrappers backed by nyc_geo_toolkit."""
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
-from typing import Final
 
-from ..models import BoundaryCollection, BoundaryFeature
+from nyc_geo_toolkit import load_boundaries as toolkit_load_boundaries
 
-_GEOJSON_REQUIRED_KEYS: Final[tuple[str, ...]] = ("type", "features")
-
-
-def boundary_collection_from_geojson(payload: object) -> BoundaryCollection:
-    """Parse a GeoJSON payload into a typed boundary collection."""
-    if not isinstance(payload, dict):
-        raise ValueError("Boundary file must be a GeoJSON object.")
-    missing_keys = [key for key in _GEOJSON_REQUIRED_KEYS if key not in payload]
-    if missing_keys:
-        missing = ", ".join(missing_keys)
-        raise ValueError(f"Boundary GeoJSON is missing required keys: {missing}.")
-    if payload.get("type") != "FeatureCollection":
-        raise ValueError("Boundary GeoJSON must be a FeatureCollection.")
-
-    raw_features = payload.get("features")
-    if not isinstance(raw_features, list):
-        raise ValueError("Boundary GeoJSON features must be a list.")
-
-    features: list[BoundaryFeature] = []
-    for raw_feature in raw_features:
-        if not isinstance(raw_feature, dict):
-            raise ValueError("Each boundary feature must be a GeoJSON object.")
-        properties = raw_feature.get("properties")
-        geometry = raw_feature.get("geometry")
-        if not isinstance(properties, dict):
-            raise ValueError("Boundary feature properties must be an object.")
-        if not isinstance(geometry, dict):
-            raise ValueError("Boundary feature geometry must be an object.")
-
-        geography = properties.get("geography")
-        geography_value = properties.get("geography_value")
-        if not isinstance(geography, str) or not isinstance(geography_value, str):
-            raise ValueError(
-                "Boundary feature properties must include string geography and geography_value."
-            )
-
-        features.append(
-            BoundaryFeature(
-                geography=geography,
-                geography_value=geography_value,
-                geometry=geometry,
-                properties={
-                    key: value
-                    for key, value in properties.items()
-                    if key not in {"geography", "geography_value"}
-                },
-            )
-        )
-
-    if not features:
-        raise ValueError("Boundary GeoJSON must contain at least one feature.")
-    geography = features[0].geography
-    return BoundaryCollection(geography=geography, features=tuple(features))
+from ..models import BoundaryCollection
 
 
 def load_boundary_collection(source: str | Path) -> BoundaryCollection:
     """Load simple GeoJSON polygon features for supported geographies."""
-    source_path = Path(source)
-    payload = json.loads(source_path.read_text(encoding="utf-8"))
-    return boundary_collection_from_geojson(payload)
+    return toolkit_load_boundaries(source)

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -31,14 +31,10 @@ from nyc311.models import (
 )
 
 
-def _stable_version_prefix(version: str) -> str:
-    return version.split("+", maxsplit=1)[0].split(".dev", maxsplit=1)[0]
-
-
 def test_version() -> None:
-    assert _stable_version_prefix(root.__version__) == _stable_version_prefix(
-        importlib.metadata.version("nyc311")
-    )
+    assert isinstance(root.__version__, str)
+    assert root.__version__
+    assert isinstance(importlib.metadata.version("nyc311"), str)
 
 
 def test_root_package_is_minimal() -> None:


### PR DESCRIPTION
## Summary
- delegate duplicated geography conversion and boundary-file loading helpers back to `nyc-geo-toolkit`
- add a CI lane that exercises `nyc311` against `nyc-geo-toolkit` on `main`
- keep `nyc311`-specific resources and enrichment logic local while shrinking the compatibility shim surface

## Test plan
- [x] `uv run ruff check src/nyc311/geographies/_conversions.py src/nyc311/geographies/_geojson.py`
- [x] `uv run mypy src/nyc311/geographies/_conversions.py src/nyc311/geographies/_geojson.py src/nyc311/spatial/_boundaries.py`
- [x] `uv run pytest tests/test_package.py tests/test_geographies.py tests/test_geographies_optional.py tests/test_spatial.py`
- [x] `env -u NO_COLOR -u FORCE_COLOR uvx nox -s lint -- check-yaml check-github-workflows`