### PR TITLE
docs: sharpen nyc311 docs tone and guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,26 +10,33 @@ CLI.
 
 Authored by [Blaise Albis-Burdige](https://blaiseab.com/).
 
-## Status
+## What this package does
 
-`nyc311` is now on the stable `0.2` line with a tested toolkit for loading,
-analyzing, and exporting NYC 311 complaint data.
+`nyc311` is the stable `0.2.x` toolkit for turning NYC 311 service-request data
+into reproducible complaint-intelligence outputs.
 
-The first public stable release shipped in `0.2.0`, and the `0.2.x` line focuses
-on packaging polish, developer ergonomics, and incremental workflow improvements
-on top of the current analysis surface.
+It pairs a thin CLI with a typed SDK so the same workflow can run in batch jobs,
+scripts, notebooks, and consumer packages.
 
-### What ships in the stable `0.2` line
+The current release line provides:
 
 - load filtered NYC 311-style records from local CSV extracts or the live
   Socrata API
-- stage reproducible local CSV snapshots from live fetches
 - derive deterministic first-pass topic labels for supported complaint types
 - aggregate complaint topics by borough or community district
 - measure topic-rule coverage and summarize resolution gaps
 - score anomalies over aggregated topic summaries
 - export CSV tables, boundary-backed GeoJSON, and markdown report cards
-- run the workflow through both a thin CLI and a composable functional SDK
+- expose the workflow through both a thin CLI and a composable functional SDK
+
+## Geography layer
+
+`nyc311.geographies` is the 311-facing compatibility layer over
+[`nyc-geo-toolkit`](https://github.com/random-walks/nyc-geo-toolkit).
+
+Use `nyc311` when you want packaged NYC boundaries inside the 311 workflow. Use
+`nyc-geo-toolkit` directly when you only need the generic geography assets,
+normalization helpers, and boundary loaders.
 
 ## Install
 
@@ -51,6 +58,18 @@ For pandas-backed conversion helpers:
 pip install "nyc311[dataframes]"
 ```
 
+For geopandas-backed geography and spatial helpers:
+
+```bash
+pip install "nyc311[spatial]"
+```
+
+For plotting helpers:
+
+```bash
+pip install "nyc311[plotting]"
+```
+
 For plotting and exploratory analysis without the geospatial stack:
 
 ```bash
@@ -63,13 +82,12 @@ NYC 311 data is one of the richest public records of neighborhood
 quality-of-life complaints in the country, but much of the useful signal is
 locked inside short text fields such as complaint descriptors.
 
-This project aims to turn those records into reusable outputs for civic
-analysis, journalism, and research while staying honest about what is truly
-implemented today.
+`nyc311` turns those records into reusable outputs for civic analysis,
+journalism, and research through an explicit, testable workflow.
 
 ## Core workflow
 
-The stable `0.2` line focuses on a deterministic, testable workflow:
+The current stable workflow is:
 
 1. load records from a local CSV extract or a filtered Socrata slice
 2. filter by date, geography, and complaint type
@@ -97,7 +115,9 @@ Docs: [Home](https://nyc311.readthedocs.io/en/latest/),
 [SDK Guide](https://nyc311.readthedocs.io/en/latest/sdk/),
 [Examples](https://nyc311.readthedocs.io/en/latest/examples/),
 [Architecture](https://nyc311.readthedocs.io/en/latest/architecture/),
-[Contributing](https://nyc311.readthedocs.io/en/latest/contributing/)
+[Contributing](https://nyc311.readthedocs.io/en/latest/contributing/),
+[Releasing](https://nyc311.readthedocs.io/en/latest/releasing/),
+[Changelog](https://nyc311.readthedocs.io/en/latest/changelog/)
 
 ## Example
 
@@ -186,12 +206,13 @@ remains descriptor-driven.
 
 ## Public package surface
 
-The current public package surface is organized around explicit namespaces:
+The public API is organized around explicit namespaces:
 
 - `nyc311.models` for dataclasses, constants, and configs
 - `nyc311.io` for CSV and Socrata loading
 - `nyc311.analysis` for topic extraction, coverage, gaps, and anomalies
-- `nyc311.geographies` for packaged boundary layers and geometry helpers
+- `nyc311.geographies` for the 311-facing compatibility layer over
+  `nyc-geo-toolkit`
 - `nyc311.samples` for packaged sample records and sample-aligned boundaries
 - `nyc311.export` for CSV, GeoJSON, and report exports
 - `nyc311.pipeline` for one-call workflow helpers

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,10 @@ package.
 The root `nyc311` package is intentionally minimal and only exposes version
 metadata. Import functionality from the canonical public modules below.
 
+`nyc311.geographies` is the one namespace that intentionally fronts another
+package: it preserves the 311-facing geography surface while delegating generic
+boundary loading and normalization primitives to `nyc-geo-toolkit`.
+
 Update docstrings and exported symbols in `src/nyc311/` rather than editing this
 reference structure by hand.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,10 +48,33 @@ flowchart LR
 - Keep the implemented surface explicit and namespaced.
 - Prefer typed inputs and outputs over implicit dictionaries.
 - Make the SDK composable for scripts, workflows, and interactive analysis.
-- Ship turnkey NYC geography layers as library-owned packaged resources.
+- Expose packaged geography access through a thin compatibility layer over
+  `nyc-geo-toolkit`.
 - Keep the CLI thin by delegating real work to importable functions.
 - Keep optional dependency boundaries explicit for dataframe, spatial, and
   notebook helpers.
+
+## Toolkit Relationship
+
+`nyc311` owns the 311-specific workflow, while `nyc-geo-toolkit` owns the
+generic NYC geography assets and normalization rules.
+
+```mermaid
+flowchart TB
+    toolkit["nyc-geo-toolkit"] --> geographies["nyc311.geographies"]
+    geographies --> exports["export_geojson()"]
+    geographies --> spatial["nyc311.spatial"]
+    geographies --> samples["nyc311.samples"]
+```
+
+That split keeps the package responsibilities clear:
+
+- `nyc311` owns complaint loading, topic analysis, exports, reports, and
+  package-specific compatibility helpers
+- `nyc-geo-toolkit` owns reusable boundary data, canonical geography
+  normalization, and generic boundary loaders
+- consumer-facing geography helpers in `nyc311` stay thin so they can track the
+  stable toolkit contract without duplicating shared implementation
 
 ## Implemented Scope
 
@@ -94,8 +117,7 @@ for:
 These packaged layers are the preferred notebook and SDK path. File-backed
 boundary loading remains available through
 `nyc311.geographies.load_boundaries()` for scripts and custom workflows, while
-the generic boundary assets and normalization logic now live in
-`nyc-geo-toolkit`.
+the generic boundary assets and normalization logic live in `nyc-geo-toolkit`.
 
 ## Maintainer Notes
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@
 
 - no unreleased changes are currently documented
 
+## 0.2.4
+
+- delegate duplicated geography conversion and boundary-loading helpers back to
+  `nyc-geo-toolkit`
+- add CI coverage against `nyc-geo-toolkit` on `main` so downstream breakage is
+  caught before release
+- stabilize compatibility and version checks across local CI, release builds,
+  and the toolkit-main validation path
+
 ## 0.2.3
 
 - refresh public authorship metadata to credit Blaise Albis-Burdige directly

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,14 +85,14 @@ session instead of running on every commit.
 Install a local hook if you want checks on commit:
 
 ```bash
-uv tool install pre-commit
-pre-commit install
+uv tool install prek
+prek install
 ```
 
 Or run the checks manually:
 
 ```bash
-pre-commit run --all-files
+prek run --all-files
 ```
 
 ## Documentation
@@ -123,43 +123,29 @@ content.
 
 ## Release Target
 
-The project is now on the stable `0.2` line.
+The project is on the stable `0.2.x` line.
 
-- Use the `0.2` line as the release framing for this branch.
+- Use the `0.2.x` line as the default release framing for this branch.
 - Use the next semantic version tag that matches the change scope, such as
-  `0.2.1`, `0.2.2`, or a future `0.3.0`.
+  `0.2.5` or a future `0.3.0`.
 - Prefer patch releases for docs, packaging, workflow, and metadata polish.
 - The project version remains VCS-derived through Hatch, so the actual package
   version will come from the eventual git tag rather than a hardcoded file edit.
 
 ## Package Publishing
 
-Distribution builds are always enabled in `.github/workflows/cd.yml`, and
-package publishing remains gated by the `PYPI_PUBLISH_ENABLED` repository
-variable.
+`nyc311` publishes through `.github/workflows/cd.yml` using the repository's
+trusted publishing setup.
 
-By default:
+The standard path is:
 
-- GitHub releases and manual `CD` runs build, validate, and smoke-test the
-  package artifacts.
-- The publish job is skipped unless publishing is explicitly enabled.
-- Artifact attestations are skipped automatically on private repositories,
-  because GitHub does not support them there.
+1. run the release-quality checks locally
+2. create and push the final tag
+3. publish the matching GitHub Release
+4. let the `release.published` trigger ship the package to PyPI
 
-To switch publishing on later:
-
-1. Configure trusted publishing on TestPyPI and PyPI for this repository. The
-   current workflow claims use repository `random-walks/nyc311`, workflow
-   `.github/workflows/cd.yml`, and environment `pypi`.
-2. Ensure the repository variable `PYPI_PUBLISH_ENABLED=true` is set.
-3. Use the manual `CD` workflow from the target tag with `publish=true` and
-   `repository=testpypi` for a dry run.
-4. Publish to real PyPI by either: `a.` creating a GitHub release from the tag
-   after enabling the variable, or `b.` running the `CD` workflow manually from
-   the target tag with `publish=true` and `repository=pypi`.
-
-The manual dispatch path is useful when you want to keep iterating on the branch
-and only publish a selected tag later.
+For a dry run, use the manual `CD` workflow on the tagged commit with
+`publish=true` and `repository=testpypi`.
 
 The full public launch checklist, including repo visibility and package-index
 setup, lives in `docs/releasing.md`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,6 +23,18 @@ For pandas-backed dataframe helpers, install:
 pip install "nyc311[dataframes]"
 ```
 
+For geopandas-backed geography and spatial helpers, install:
+
+```bash
+pip install "nyc311[spatial]"
+```
+
+For plotting helpers, install:
+
+```bash
+pip install "nyc311[plotting]"
+```
+
 For plotting and exploratory analysis without the geospatial stack, install:
 
 ```bash
@@ -55,6 +67,23 @@ The implemented loader expects NYC 311-style records with these columns:
 `summaries_to_dataframe()`, `gaps_to_dataframe()`, `anomalies_to_dataframe()`,
 `coverage_to_dataframe()`, and `dataframe_to_records()` require the `dataframes`
 extra (or the broader `science` extra) because they depend on pandas.
+
+## Geography helpers
+
+`nyc311.geographies` preserves a 311-facing packaged-boundary surface while the
+generic boundary assets and normalization logic live in `nyc-geo-toolkit`.
+
+The base install already supports typed packaged boundary loading:
+
+```python
+from nyc311 import geographies
+
+print(geographies.list_boundary_layers())
+boroughs = geographies.load_nyc_boundaries("borough")
+```
+
+If you want GeoDataFrame loaders, spatial joins, or plotting-backed notebooks,
+install the relevant optional extras first.
 
 ## First Snapshot Run
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ It is designed for two complementary use cases:
 
 These docs track the current stable `0.2.x` surface.
 
-The `0.2` release line ships a complete first-pass analysis workflow:
+The current release line provides:
 
 - loading filtered NYC 311-style records from local CSV extracts
 - loading filtered records from the live NYC Socrata API
@@ -20,6 +20,13 @@ The `0.2` release line ships a complete first-pass analysis workflow:
 - aggregation by borough or community district
 - topic-coverage, resolution-gap, and anomaly analysis helpers
 - CSV, boundary-backed GeoJSON, and markdown report exports
+
+## Geography layer
+
+`nyc311.geographies` is the 311-facing compatibility layer over
+[`nyc-geo-toolkit`](https://github.com/random-walks/nyc-geo-toolkit). It keeps
+the packaged boundary workflow available inside `nyc311` while the generic
+boundary assets and normalization logic live in the shared toolkit package.
 
 ## Docs Paths
 
@@ -43,6 +50,18 @@ For pandas-backed conversion helpers:
 
 ```bash
 pip install "nyc311[dataframes]"
+```
+
+For geopandas-backed geography and spatial helpers:
+
+```bash
+pip install "nyc311[spatial]"
+```
+
+For plotting helpers:
+
+```bash
+pip install "nyc311[plotting]"
 ```
 
 For plotting and exploratory analysis without the geospatial stack:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,15 +1,19 @@
 # Releasing
 
-This guide covers the stable PyPI release workflow for `nyc311`.
+This guide covers the current PyPI release workflow for `nyc311`.
 
-## Release Shape
+## Release discipline
 
-- Stable line: `0.2`
-- Current patch target example: `0.2.1`
+- Current stable line: `0.2.x`
 - Version source: git tags via Hatch VCS
 - Preferred publish trigger: GitHub Release publication
 
-## Phase 1: Repo Polish
+Patch releases in the `0.2.x` line are the default path for docs polish,
+workflow updates, packaging fixes, and backward-compatible behavior changes. Cut
+a new minor release when the public workflow or package surface expands in a
+meaningful way.
+
+## Pre-release checks
 
 Before cutting a release tag, make sure the repo passes:
 
@@ -28,7 +32,37 @@ That covers:
 - PyPI long-description validation
 - installed-wheel smoke testing for the CLI and packaged resources
 
-## Bootstrap Checklist
+If the release touches `nyc311.geographies` or dependency ranges, also verify
+the current `nyc-geo-toolkit` compatibility path before tagging.
+
+## Release path
+
+The standard production path is:
+
+1. create the final release tag, for example `0.2.5`
+2. push the tag
+3. optionally run the `CD` workflow against TestPyPI first
+4. publish the matching GitHub Release
+5. let the `release.published` trigger publish to real PyPI
+
+If you prefer the manual route, run the `CD` workflow from the same tag with:
+
+- `publish=true`
+- `repository=pypi`
+
+## Trusted publishing setup
+
+This repo uses trusted publishing through `.github/workflows/cd.yml` and the
+`pypi` GitHub environment.
+
+If you ever need to recreate that setup, verify:
+
+- owner: `random-walks`
+- repository: `nyc311`
+- workflow: `.github/workflows/cd.yml`
+- environment: `pypi`
+
+## Bootstrap checklist
 
 These one-time steps must be completed by a human account owner before the
 trusted publishing flow can be used:
@@ -50,8 +84,6 @@ trusted publishing flow can be used:
    - Topics
    - Homepage / docs URL
    - Social preview
-7. Decide when the repository will become public relative to the release tag and
-   GitHub Release window.
 
 Important: a pending trusted publisher does not reserve the PyPI name until it
 is used successfully for the first publish.
@@ -60,7 +92,7 @@ is used successfully for the first publish.
 
 For routine releases, do one dry run from the final release tag:
 
-1. Create the release tag, for example `0.2.1`.
+1. Create the release tag, for example `0.2.5`.
 2. Push the tag.
 3. Run the `CD` workflow manually from that tag with:
    - `publish=true`
@@ -81,19 +113,6 @@ If you want the optional stacks too:
 ```bash
 .venv-testpypi-check/bin/python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple "nyc311[all]"
 ```
-
-## Production Release
-
-Once the TestPyPI dry run passes:
-
-1. Confirm the `pypi` environment and `PYPI_PUBLISH_ENABLED=true` are in place.
-2. Publish a GitHub Release from the tag.
-
-The `release.published` trigger will publish to real PyPI automatically. If you
-prefer a manual path instead, run the `CD` workflow from the same tag with:
-
-- `publish=true`
-- `repository=pypi`
 
 ## Post-Release Verification
 


### PR DESCRIPTION
## Summary
- tighten the README and core docs language around the stable `0.2.x` package surface
- document the `nyc311` / `nyc-geo-toolkit` relationship more clearly across user-facing and maintainer docs
- refresh install, contributor, release, and changelog guidance to match the current workflow

## Test plan
- [x] `make lint-fix`
- [x] `make ci`

Made with [Cursor](https://cursor.com)