### PR TITLE
docs: align nyc311 changelog with recent docs releases

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,21 @@
 
 - no unreleased changes are currently documented
 
+## 0.2.6
+
+- align the published changelog with the docs refresh that already shipped in
+  `0.2.5`
+- keep the public docs, release notes, and package history in sync after the
+  docs-only follow-up patch
+
+## 0.2.5
+
+- sharpen the README and core docs around the stable `0.2.x` package surface
+- document the `nyc311` and `nyc-geo-toolkit` relationship more clearly across
+  user-facing and maintainer docs
+- refresh install, contributor, and release guidance to match the current
+  workflow
+
 ## 0.2.4
 
 - delegate duplicated geography conversion and boundary-loading helpers back to


### PR DESCRIPTION
## Summary
- restore the missing `0.2.5` changelog entry after the docs refresh release
- add a `0.2.6` docs-only follow-up entry so the public changelog matches the release history
- keep Read the Docs and package release history aligned

## Test plan
- [x] `make lint-fix`
- [x] `make ci`

Made with [Cursor](https://cursor.com)