### PR TITLE
Fix CI: Ruff, mypy, and prek (docs/markdown hygiene)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ panel.xs("BROOKLYN")["Noise - Residential"].plot()
 
 - **Socrata:** dataset `erm2-nwe9` (NYC 311 Service Requests from 2010 onward;
   tens of millions of rows). Use `presets.large_socrata_config()` for bulk
-  pagination (default 5,000 rows per HTTP request) and `nyc311.io.cached_fetch` to
-  stream pages to CSV without holding the full history in memory.
+  pagination (default 5,000 rows per HTTP request) and `nyc311.io.cached_fetch`
+  to stream pages to CSV without holding the full history in memory.
 - **Boundaries:** borough, community district, council district, NTA, census
   tract, and ZCTA layers ship through `nyc311.geographies` (built on
   `nyc-geo-toolkit`).

--- a/examples/about-the-data/README.md
+++ b/examples/about-the-data/README.md
@@ -6,26 +6,25 @@ Kitchen-sink catalogue and figure pipeline for NYC 311: maximum Socrata surface
 Layout mirrors the ecosystem pattern used in
 [`subway-access` about-the-data](https://github.com/random-walks/subway-access/tree/main/examples/about-the-data):
 
-
 | Script                         | Role                                                            |
 | ------------------------------ | --------------------------------------------------------------- |
 | `[download.py](./download.py)` | Socrata bulk slices + boundary GeoJSON under `cache/`           |
 | `[analyze.py](./analyze.py)`   | Catalogue + PNG figures + `reports/about-the-data-tearsheet.md` |
 | `[main.py](./main.py)`         | Runs download then analysis (same flags as both)                |
 
-
 ## Presets
-
 
 | `--preset`       | Sort                           | Row cap                      | Default timeout / page         |
 | ---------------- | ------------------------------ | ---------------------------- | ------------------------------ |
 | `full` (default) | Oldest first (`ASC`)           | None (full history)          | 300s per request, 5k rows/page |
 | `smoke`          | **Most recent first** (`DESC`) | **100,000 rows per borough** | 120s per request, 5k rows/page |
 
+Smoke mode is for **quick end-to-end checks** across all five boroughs without a
+multi-hour pull. Full mode is the long-running **chronological** extract.
 
-Smoke mode is for **quick end-to-end checks** across all five boroughs without a multi-hour pull. Full mode is the long-running **chronological** extract.
-
-During download, **per-page progress** lines print by default (`[BRONX] page 1: 5000 rows (running total 5000)`). Use `--no-progress` to silence them.
+During download, **per-page progress** lines print by default
+(`[BRONX] page 1: 5000 rows (running total 5000)`). Use `--no-progress` to
+silence them.
 
 ## Run
 
@@ -34,7 +33,8 @@ uv sync
 uv run python main.py
 ```
 
-**Smoke test (all boroughs, 100k rows each, recent data first — large enough for figures, small enough to finish in reasonable time):**
+**Smoke test (all boroughs, 100k rows each, recent data first — large enough for
+figures, small enough to finish in reasonable time):**
 
 ```bash
 uv run python download.py --preset smoke -v
@@ -46,18 +46,27 @@ uv run python download.py --preset smoke -v
 uv run python download.py --preset full -v
 ```
 
-**Since 2026-01-01, all boroughs, no per-borough row cap** (chronological `ASC` order; narrow window via `--start-date`):
+**Since 2026-01-01, all boroughs, no per-borough row cap** (chronological `ASC`
+order; narrow window via `--start-date`):
 
 ```bash
 uv run python download.py --preset full --start-date 2026-01-01 -v
 uv run python analyze.py --clear-figures --clear-report
 ```
 
-Use `--refresh` if older CSVs in the same `cache/records/...` folders would otherwise be skipped. Smoke (`--preset smoke`) pulls **recent-first** (`DESC`) capped slices — fine for visuals, but **daily/monthly time-series levels are not representative** of long-run history; the tearsheet footnote calls this out when `_desc` cache files are present.
+Use `--refresh` if older CSVs in the same `cache/records/...` folders would
+otherwise be skipped. Smoke (`--preset smoke`) pulls **recent-first** (`DESC`)
+capped slices — fine for visuals, but **daily/monthly time-series levels are not
+representative** of long-run history; the tearsheet footnote calls this out when
+`_desc` cache files are present.
 
 ### Borough-by-borough (resumable)
 
-Each borough writes **one** deterministic CSV under `cache/records/<borough_slug>/`. Completed files are **skipped** on the next run unless you pass `--refresh`. Interrupted runs only leave a `*.csv.part` file (never a complete `*.csv`); the next run removes the partial and retries that slice.
+Each borough writes **one** deterministic CSV under
+`cache/records/<borough_slug>/`. Completed files are **skipped** on the next run
+unless you pass `--refresh`. Interrupted runs only leave a `*.csv.part` file
+(never a complete `*.csv`); the next run removes the partial and retries that
+slice.
 
 **All five** (default):
 
@@ -105,25 +114,29 @@ uv run python main.py \
 
 Set `NYC_OPEN_DATA_APP_TOKEN` (or pass `--app-token`) for higher Socrata rate
 limits on large pulls. If you see `TimeoutError` while reading a page, raise
-`--request-timeout` (defaults: 300s for `full`, 120s for `smoke`; try `600` on slow links).
+`--request-timeout` (defaults: 300s for `full`, 120s for `smoke`; try `600` on
+slow links).
 
-**Order of operations:** finish `download.py` (or `main.py` without `--skip-download`)
-before `analyze.py`. Figures read from `cache/` only; wiping `cache/` and running
-`analyze.py` alone will not pull new data.
+**Order of operations:** finish `download.py` (or `main.py` without
+`--skip-download`) before `analyze.py`. Figures read from `cache/` only; wiping
+`cache/` and running `analyze.py` alone will not pull new data.
 
 ## Full history vs small samples
 
-The **full** preset uses **no per-borough cap** unless you pass `--max-records-per-borough`
-and streams **one CSV per borough** via `nyc311.io.cached_fetch` with
-`presets.large_socrata_config()` (**5,000 rows per HTTP page** by default). That is the path to the **full public dataset** (tens of millions of rows
-total, hours of runtime, large `cache/`).
+The **full** preset uses **no per-borough cap** unless you pass
+`--max-records-per-borough` and streams **one CSV per borough** via
+`nyc311.io.cached_fetch` with `presets.large_socrata_config()` (**5,000 rows per
+HTTP page** by default). That is the path to the **full public dataset** (tens
+of millions of rows total, hours of runtime, large `cache/`).
 
 If you only see **~20 rows** under `cache/records/...`, that is **not** a live
 Socrata pull: it is almost certainly a **local test fixture** copied into
 `cache/` for offline figure development. Delete `cache/` and run **without**
-`--skip-download` to fetch real data, or use `--preset smoke` / `--max-records-per-borough` when you want a bounded sample on
-purpose.
+`--skip-download` to fetch real data, or use `--preset smoke` /
+`--max-records-per-borough` when you want a bounded sample on purpose.
 
 **Different date ranges** produce **different filenames** (dates are baked into
-the CSV name). **DESC** (smoke) slices also get a `_desc` suffix so they never collide with chronological `full` extracts. To align boroughs, use the same `--start-date` / `--end-date`
-everywhere, or remove older CSVs and re-fetch with `--refresh`.
+the CSV name). **DESC** (smoke) slices also get a `_desc` suffix so they never
+collide with chronological `full` extracts. To align boroughs, use the same
+`--start-date` / `--end-date` everywhere, or remove older CSVs and re-fetch with
+`--refresh`.

--- a/examples/about-the-data/analysis_logic.py
+++ b/examples/about-the-data/analysis_logic.py
@@ -47,6 +47,7 @@ def _footnote_figure(fig: Any, footnote: str | None) -> None:
         va="bottom",
     )
 
+
 # --- Section 1: catalogue ---
 
 
@@ -100,10 +101,18 @@ def _scan_borough_csv(csv_path: Path) -> dict[str, Any]:
         cmin = chunk["created_date"].min()
         cmax = chunk["created_date"].max()
         if pd.notna(cmin):
-            dmin = cmin.date() if hasattr(cmin, "date") else date.fromisoformat(str(cmin)[:10])
+            dmin = (
+                cmin.date()
+                if hasattr(cmin, "date")
+                else date.fromisoformat(str(cmin)[:10])
+            )
             min_d = dmin if min_d is None else min(min_d, dmin)
         if pd.notna(cmax):
-            dmax = cmax.date() if hasattr(cmax, "date") else date.fromisoformat(str(cmax)[:10])
+            dmax = (
+                cmax.date()
+                if hasattr(cmax, "date")
+                else date.fromisoformat(str(cmax)[:10])
+            )
             max_d = dmax if max_d is None else max(max_d, dmax)
     return {
         "total": total,
@@ -117,9 +126,7 @@ def _scan_borough_csv(csv_path: Path) -> dict[str, Any]:
     }
 
 
-def build_catalogue(
-    cache_root: Path, boroughs: tuple[str, ...]
-) -> CatalogueSummary:
+def build_catalogue(cache_root: Path, boroughs: tuple[str, ...]) -> CatalogueSummary:
     rows: list[BoroughCatalogueRow] = []
     for b in boroughs:
         bdir = borough_cache_dir(cache_root, b)
@@ -274,12 +281,20 @@ def sample_eda_figures(
     fig3.savefig(p3, bbox_inches="tight", dpi=150)
     plt.close(fig3)
     # resolution rate by CD (sample)
-    cd_col = "community_district" if "community_district" in all_df.columns else "community_board"
+    cd_col = (
+        "community_district"
+        if "community_district" in all_df.columns
+        else "community_board"
+    )
     rates = []
     for cd, g in all_df.groupby(cd_col):
         if len(g) < 5:
             continue
-        r = g["resolution_description"].notna().mean() if "resolution_description" in g.columns else 0.0
+        r = (
+            g["resolution_description"].notna().mean()
+            if "resolution_description" in g.columns
+            else 0.0
+        )
         rates.append(float(r))
     fig4 = plotting.plot_bar_counts(
         [str(i) for i in range(len(rates))],
@@ -318,9 +333,7 @@ def timeseries_figures(
     frames: list[pd.DataFrame] = []
     for b in boroughs:
         for p in borough_cache_dir(cache_root, b).glob("*.csv"):
-            frames.append(
-                pd.read_csv(p, nrows=800_000, parse_dates=["created_date"])
-            )
+            frames.append(pd.read_csv(p, nrows=800_000, parse_dates=["created_date"]))
     if not frames:
         placeholder = figures_dir / "timeseries-placeholder.png"
         placeholder.write_bytes(b"")
@@ -328,7 +341,11 @@ def timeseries_figures(
             placeholder, placeholder, placeholder, placeholder, placeholder, None
         )
     df = pd.concat(frames, ignore_index=True)
-    fn = _desc_sample_footnote() if _cache_uses_desc_sample(cache_root, boroughs) else None
+    fn = (
+        _desc_sample_footnote()
+        if _cache_uses_desc_sample(cache_root, boroughs)
+        else None
+    )
     df["day"] = pd.to_datetime(df["created_date"]).dt.floor("D")
     daily = df.groupby("day").size()
     daily_df = pd.DataFrame({"count": daily})
@@ -370,7 +387,9 @@ def timeseries_figures(
     top4 = df["complaint_type"].value_counts().head(4).index
     # faceted heatmap: concatenate subplots manually — single combined for v1
     sub = df[df["complaint_type"].isin(top4)]
-    fig5 = plotting.plot_complaint_heatmap(sub, title="Hour × weekday (top types sample)")
+    fig5 = plotting.plot_complaint_heatmap(
+        sub, title="Hour × weekday (top types sample)"
+    )
     _footnote_figure(fig5, fn)
     p_hmt = figures_dir / "heatmap-hour-weekday-by-type.png"
     fig5.savefig(p_hmt, bbox_inches="tight", dpi=150)
@@ -378,7 +397,9 @@ def timeseries_figures(
     seasonal_path: Path | None = None
     noise = df[df["complaint_type"] == "Noise - Residential"].copy()
     if len(noise) > 24:
-        noise["m"] = pd.to_datetime(noise["created_date"]).dt.to_period("M").dt.to_timestamp()
+        noise["m"] = (
+            pd.to_datetime(noise["created_date"]).dt.to_period("M").dt.to_timestamp()
+        )
         monthly_n = noise.groupby("m").size()
         try:
             from statsmodels.tsa.seasonal import STL
@@ -438,7 +459,11 @@ def choropleth_figures(
         empty: list[tuple[str, Path]] = []
         return ChoroplethPaths(ph, ph, ph, ph, empty)
     df = pd.concat(frames, ignore_index=True)
-    cd_col = "community_district" if "community_district" in df.columns else "community_board"
+    cd_col = (
+        "community_district"
+        if "community_district" in df.columns
+        else "community_board"
+    )
     cd_counts = df.groupby(cd_col).size().rename("n")
     gdf = geographies.load_nyc_boundaries_geodataframe("community_district")
     merged = gdf.merge(
@@ -480,8 +505,12 @@ def choropleth_figures(
     )
     figb.savefig(p2, bbox_inches="tight", dpi=150)
     plt.close(figb)
-    res_rate = df.groupby(cd_col)["resolution_description"].apply(lambda s: s.isna().mean())
-    m3 = gdf.merge(res_rate.rename("gap"), left_on="geography_value", right_index=True, how="left")
+    res_rate = df.groupby(cd_col)["resolution_description"].apply(
+        lambda s: s.isna().mean()
+    )
+    m3 = gdf.merge(
+        res_rate.rename("gap"), left_on="geography_value", right_index=True, how="left"
+    )
     m3["gap"] = m3["gap"].fillna(0)
     figc = plotting.plot_boundary_choropleth(
         m3,
@@ -728,7 +757,9 @@ def analysis_figures(
     p2 = figures_dir / "topic-anomaly-zscores.png"
     fig2.savefig(p2, bbox_inches="tight", dpi=150)
     plt.close(fig2)
-    rep0 = analysis.analyze_topic_coverage(recs, models.TopicQuery(ALL_COMPLAINT_TYPES[0]))
+    rep0 = analysis.analyze_topic_coverage(
+        recs, models.TopicQuery(ALL_COMPLAINT_TYPES[0])
+    )
     fig3 = plotting.plot_bar_counts(
         [d for d, _ in rep0.top_unmatched_descriptors],
         [float(c) for _, c in rep0.top_unmatched_descriptors],
@@ -738,7 +769,9 @@ def analysis_figures(
     p3 = figures_dir / "top-unmatched-descriptors.png"
     fig3.savefig(p3, bbox_inches="tight", dpi=150)
     plt.close(fig3)
-    br = df.groupby("borough")["resolution_description"].apply(lambda s: s.isna().mean())
+    br = df.groupby("borough")["resolution_description"].apply(
+        lambda s: s.isna().mean()
+    )
     fig4 = plotting.plot_bar_counts(
         [str(x) for x in br.index],
         [float(x) for x in br.values],

--- a/examples/about-the-data/analyze.py
+++ b/examples/about-the-data/analyze.py
@@ -57,7 +57,9 @@ def run_analyze(args: argparse.Namespace) -> None:
     if not args.skip_choropleth:
         analysis_logic.choropleth_figures(cache_root, boroughs, figures_dir=FIGURES_DIR)
     if not args.skip_scatter:
-        analysis_logic.scatter_map_figures(cache_root, boroughs, figures_dir=FIGURES_DIR)
+        analysis_logic.scatter_map_figures(
+            cache_root, boroughs, figures_dir=FIGURES_DIR
+        )
         _publish_readme_hero_from_scatter_cover()
     if not args.skip_hero:
         analysis_logic.hero_image_figures(cache_root, boroughs, figures_dir=FIGURES_DIR)

--- a/examples/about-the-data/download_logic.py
+++ b/examples/about-the-data/download_logic.py
@@ -211,9 +211,7 @@ def download_per_type_records(
     return out
 
 
-def download_boundary_layers(
-    cache_root: Path, *, refresh: bool
-) -> dict[str, Path]:
+def download_boundary_layers(cache_root: Path, *, refresh: bool) -> dict[str, Path]:
     """Write packaged boundary layers as GeoJSON under ``cache/boundaries/``."""
     root = Path(cache_root) / "boundaries"
     root.mkdir(parents=True, exist_ok=True)

--- a/examples/about-the-data/reports/about-the-data-tearsheet.md
+++ b/examples/about-the-data/reports/about-the-data-tearsheet.md
@@ -10,25 +10,25 @@
 
 ## Catalogue
 
-| Borough | Records | Types seen | Supported-type rows | Date start | Date end | With coords | With resolution | CDs seen | Cache bytes |
-|---|---:|---:|---:|---|---|---:|---:|---:|---:|
-| BRONX | 100000 | 148 | 60951 | 2026-02-18 | 2026-04-05 | 96921 | 98105 | 17 | 47121280 |
-| BROOKLYN | 100000 | 156 | 57059 | 2026-03-05 | 2026-04-05 | 96889 | 94901 | 21 | 46643749 |
-| MANHATTAN | 100000 | 162 | 45012 | 2026-02-15 | 2026-04-05 | 97148 | 94060 | 15 | 44447120 |
-| QUEENS | 100000 | 154 | 58594 | 2026-02-28 | 2026-04-05 | 91017 | 96147 | 20 | 44299495 |
-| STATEN ISLAND | 100000 | 153 | 36979 | 2025-08-21 | 2026-04-05 | 96834 | 97953 | 5 | 37028395 |
+| Borough       | Records | Types seen | Supported-type rows | Date start | Date end   | With coords | With resolution | CDs seen | Cache bytes |
+| ------------- | ------: | ---------: | ------------------: | ---------- | ---------- | ----------: | --------------: | -------: | ----------: |
+| BRONX         |  100000 |        148 |               60951 | 2026-02-18 | 2026-04-05 |       96921 |           98105 |       17 |    47121280 |
+| BROOKLYN      |  100000 |        156 |               57059 | 2026-03-05 | 2026-04-05 |       96889 |           94901 |       21 |    46643749 |
+| MANHATTAN     |  100000 |        162 |               45012 | 2026-02-15 | 2026-04-05 |       97148 |           94060 |       15 |    44447120 |
+| QUEENS        |  100000 |        154 |               58594 | 2026-02-28 | 2026-04-05 |       91017 |           96147 |       20 |    44299495 |
+| STATEN ISLAND |  100000 |        153 |               36979 | 2025-08-21 | 2026-04-05 |       96834 |           97953 |        5 |    37028395 |
 
 ## Source layers
 
-| Name | URL / file | Rows / features |
-|---|---|---:|
-| NYC 311 Service Requests | https://data.cityofnewyork.us/resource/erm2-nwe9.json | 500000 |
-| borough | borough.geojson | 5 |
-| census_tract | census_tract.geojson | 2325 |
-| community_district | community_district.geojson | 59 |
-| council_district | council_district.geojson | 51 |
-| neighborhood_tabulation_area | neighborhood_tabulation_area.geojson | 262 |
-| zcta | zcta.geojson | 178 |
+| Name                         | URL / file                                            | Rows / features |
+| ---------------------------- | ----------------------------------------------------- | --------------: |
+| NYC 311 Service Requests     | https://data.cityofnewyork.us/resource/erm2-nwe9.json |          500000 |
+| borough                      | borough.geojson                                       |               5 |
+| census_tract                 | census_tract.geojson                                  |            2325 |
+| community_district           | community_district.geojson                            |              59 |
+| council_district             | council_district.geojson                              |              51 |
+| neighborhood_tabulation_area | neighborhood_tabulation_area.geojson                  |             262 |
+| zcta                         | zcta.geojson                                          |             178 |
 
 ## EDA tables (CSV)
 
@@ -39,63 +39,62 @@ Machine-readable slices written next to this report. Preview (truncated) below.
 [Download CSV](tables/sample_summary.csv)
 
 | desc_sample_cache | rows_loaded | min_created_date | max_created_date |
-|---|---|---|---|
-| True | 500000 | 2025-08-21 | 2026-04-05 |
+| ----------------- | ----------- | ---------------- | ---------------- |
+| True              | 500000      | 2025-08-21       | 2026-04-05       |
 
 ### `rows_by_borough.csv`
 
 [Download CSV](tables/rows_by_borough.csv)
 
-| borough | count |
-|---|---|
-| BRONX | 100000 |
-| BROOKLYN | 100000 |
-| MANHATTAN | 100000 |
-| QUEENS | 100000 |
+| borough       | count  |
+| ------------- | ------ |
+| BRONX         | 100000 |
+| BROOKLYN      | 100000 |
+| MANHATTAN     | 100000 |
+| QUEENS        | 100000 |
 | STATEN ISLAND | 100000 |
 
 ### `top_complaint_types_citywide.csv`
 
 [Download CSV](tables/top_complaint_types_citywide.csv)
 
-| complaint_type | count |
-|---|---|
-| Illegal Parking | 71519 |
-| Noise - Residential | 45661 |
-| HEAT/HOT WATER | 42767 |
-| Street Condition | 34187 |
-| Blocked Driveway | 21954 |
-| Snow or Ice | 18860 |
-| UNSANITARY CONDITION | 14410 |
-| Noise - Street/Sidewalk | 14241 |
-| Dirty Condition | 10980 |
-| Abandoned Vehicle | 10958 |
-| Water System | 10189 |
-| Traffic Signal Condition | 9906 |
-| PLUMBING | 9756 |
-| Noise | 8456 |
+| complaint_type           | count |
+| ------------------------ | ----- |
+| Illegal Parking          | 71519 |
+| Noise - Residential      | 45661 |
+| HEAT/HOT WATER           | 42767 |
+| Street Condition         | 34187 |
+| Blocked Driveway         | 21954 |
+| Snow or Ice              | 18860 |
+| UNSANITARY CONDITION     | 14410 |
+| Noise - Street/Sidewalk  | 14241 |
+| Dirty Condition          | 10980 |
+| Abandoned Vehicle        | 10958 |
+| Water System             | 10189 |
+| Traffic Signal Condition | 9906  |
+| PLUMBING                 | 9756  |
+| Noise                    | 8456  |
 
 ### `daily_counts_last_45_days.csv`
 
 [Download CSV](tables/daily_counts_last_45_days.csv)
 
-| day | count |
-|---|---|
-| 2026-02-20 | 4597 |
-| 2026-02-21 | 3982 |
-| 2026-02-22 | 3872 |
-| 2026-02-23 | 8166 |
+| day        | count |
+| ---------- | ----- |
+| 2026-02-20 | 4597  |
+| 2026-02-21 | 3982  |
+| 2026-02-22 | 3872  |
+| 2026-02-23 | 8166  |
 | 2026-02-24 | 11375 |
-| 2026-02-25 | 6308 |
-| 2026-02-26 | 5138 |
-| 2026-02-27 | 4893 |
-| 2026-02-28 | 5435 |
-| 2026-03-01 | 6359 |
-| 2026-03-02 | 7568 |
-| 2026-03-03 | 7029 |
-| 2026-03-04 | 7888 |
-| 2026-03-05 | 8486 |
-
+| 2026-02-25 | 6308  |
+| 2026-02-26 | 5138  |
+| 2026-02-27 | 4893  |
+| 2026-02-28 | 5435  |
+| 2026-03-01 | 6359  |
+| 2026-03-02 | 7568  |
+| 2026-03-03 | 7029  |
+| 2026-03-04 | 7888  |
+| 2026-03-05 | 8486  |
 
 ## Figures
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ test = [
 dev = [
   { include-group = "test" },
   "mypy >=1.18",
+  "pandas-stubs >=2.3.0",
   "pylint >=3.3",
   "ruff >=0.12",
 ]

--- a/src/nyc311/dataframes/_timeseries.py
+++ b/src/nyc311/dataframes/_timeseries.py
@@ -31,9 +31,7 @@ def to_timeseries(
     freq = _normalize_pandas_freq(freq)
     dataframe = records_to_dataframe(records)
     counts = (
-        dataframe.groupby(
-            [pd.Grouper(key="created_date", freq=freq), "complaint_type"]
-        )
+        dataframe.groupby([pd.Grouper(key="created_date", freq=freq), "complaint_type"])
         .size()
         .unstack(fill_value=0)
     )

--- a/src/nyc311/geographies/_conversions.py
+++ b/src/nyc311/geographies/_conversions.py
@@ -14,7 +14,7 @@ from nyc_geo_toolkit import (
 from ..models import BoundaryCollection
 
 if TYPE_CHECKING:
-    import pandas as pd  # type: ignore[import-untyped]
+    import pandas as pd
 
 
 def boundaries_to_geojson(boundaries: BoundaryCollection) -> dict[str, object]:

--- a/src/nyc311/io/_cache.py
+++ b/src/nyc311/io/_cache.py
@@ -60,7 +60,9 @@ def cache_path_for_request(
     return cache_dir / name
 
 
-def _write_record_row(writer: csv.DictWriter, record: ServiceRequestRecord) -> None:
+def _write_record_row(
+    writer: csv.DictWriter[str], record: ServiceRequestRecord
+) -> None:
     writer.writerow(
         {
             "unique_key": record.service_request_id,

--- a/src/nyc311/io/_cache.py
+++ b/src/nyc311/io/_cache.py
@@ -119,9 +119,7 @@ def cached_fetch(
     written = 0
     try:
         with partial_path.open("w", newline="", encoding="utf-8") as csv_file:
-            writer = csv.DictWriter(
-                csv_file, fieldnames=SERVICE_REQUEST_EXPORT_COLUMNS
-            )
+            writer = csv.DictWriter(csv_file, fieldnames=SERVICE_REQUEST_EXPORT_COLUMNS)
             writer.writeheader()
             for record in iter_service_requests_from_socrata(
                 socrata_config,

--- a/src/nyc311/io/_socrata.py
+++ b/src/nyc311/io/_socrata.py
@@ -133,9 +133,7 @@ def _read_socrata_page_once(
         raw = response.read().decode("utf-8")
     payload = json.loads(raw)
     if not isinstance(payload, list):
-        raise ValueError(
-            "Unexpected Socrata response payload; expected a JSON list."
-        )
+        raise ValueError("Unexpected Socrata response payload; expected a JSON list.")
     return payload
 
 

--- a/src/nyc311/plotting.py
+++ b/src/nyc311/plotting.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
+from typing import Any, cast
 
 
 def _require_matplotlib() -> Any:
@@ -580,9 +580,12 @@ def plot_hero_banner(
     boundary_frame = boundaries_gdf
     if bbox is not None:
         minx, miny, maxx, maxy = bbox
-        point_frame = points_gdf.cx[minx:maxx, miny:maxy]
+        # GeoPandas uses float coordinate bounds; slice() in typeshed is int-only.
+        x_slice = slice(cast(Any, minx), cast(Any, maxx))
+        y_slice = slice(cast(Any, miny), cast(Any, maxy))
+        point_frame = points_gdf.cx[x_slice, y_slice]
         if boundaries_gdf is not None:
-            boundary_frame = boundaries_gdf.cx[minx:maxx, miny:maxy]
+            boundary_frame = boundaries_gdf.cx[x_slice, y_slice]
 
     point_frame = _prepare_plot_frame(point_frame, add_basemap=True)
     boundary_frame = _prepare_plot_frame(boundary_frame, add_basemap=True)

--- a/src/nyc311/plotting.py
+++ b/src/nyc311/plotting.py
@@ -73,7 +73,9 @@ def _apply_top_n_categorical_point_legend(
     leg = axes.get_legend()
     if leg is None:
         return
-    handles = list(getattr(leg, "legend_handles", None) or getattr(leg, "legendHandles", []))
+    handles = list(
+        getattr(leg, "legend_handles", None) or getattr(leg, "legendHandles", [])
+    )
     texts = [t.get_text() for t in leg.get_texts()]
     n = min(len(handles), len(texts))
     by_label: dict[str, Any] = dict(zip(texts[:n], handles[:n], strict=True))
@@ -455,7 +457,9 @@ def plot_stacked_area(
     pd = import_module("pandas")
     plt.style.use("seaborn-v0_8-whitegrid")
     if not isinstance(dataframe.index, pd.DatetimeIndex):
-        raise TypeError("plot_stacked_area() expects a DatetimeIndex-indexed DataFrame.")
+        raise TypeError(
+            "plot_stacked_area() expects a DatetimeIndex-indexed DataFrame."
+        )
     totals = dataframe.sum().sort_values(ascending=False)
     cols = list(totals.head(top_n).index)
     sub = dataframe[cols].fillna(0)
@@ -520,7 +524,9 @@ def plot_complaint_scatter(
     point_frame = _prepare_plot_frame(points_gdf, add_basemap=add_basemap)
     boundary_frame = _prepare_plot_frame(boundaries_gdf, add_basemap=add_basemap)
     if point_frame is None or point_frame.empty:
-        raise TypeError("plot_complaint_scatter() requires a non-empty points GeoDataFrame.")
+        raise TypeError(
+            "plot_complaint_scatter() requires a non-empty points GeoDataFrame."
+        )
 
     _figure, axes = plt.subplots(figsize=figsize)
     scatter_legend_kwds = {"bbox_to_anchor": (1.02, 1), "loc": "upper left"}
@@ -586,7 +592,9 @@ def plot_hero_banner(
     _figure, axes = plt.subplots(figsize=figsize)
     hero_legend_kwds = {"bbox_to_anchor": (1.01, 1), "loc": "upper left", "fontsize": 8}
     if boundary_frame is not None and not boundary_frame.empty:
-        boundary_frame.boundary.plot(ax=axes, color="#0f172a", linewidth=0.9, alpha=0.85)
+        boundary_frame.boundary.plot(
+            ax=axes, color="#0f172a", linewidth=0.9, alpha=0.85
+        )
     point_frame.plot(
         ax=axes,
         column=column,

--- a/tests/test_io_cache.py
+++ b/tests/test_io_cache.py
@@ -34,9 +34,7 @@ def _sample_records() -> list[ServiceRequestRecord]:
 
 def test_cache_path_unfiltered() -> None:
     cfg = SocrataConfig(page_size=1000)
-    flt = ServiceRequestFilter(
-        start_date=date(2024, 1, 1), end_date=date(2024, 1, 31)
-    )
+    flt = ServiceRequestFilter(start_date=date(2024, 1, 1), end_date=date(2024, 1, 31))
     p = cache_path_for_request(cfg, flt, Path("/tmp/cache"))
     assert p.name == "all_2024-01-01_2024-01-31_1000.csv"
 

--- a/tests/test_timeseries_helpers.py
+++ b/tests/test_timeseries_helpers.py
@@ -14,7 +14,11 @@ from nyc311.dataframes import (
 from nyc311.io import load_service_requests
 from nyc311.models import TopicQuery
 
-FIXTURE_PATH = __import__("pathlib").Path(__file__).parent / "fixtures" / "service_requests_fixture.csv"
+FIXTURE_PATH = (
+    __import__("pathlib").Path(__file__).parent
+    / "fixtures"
+    / "service_requests_fixture.csv"
+)
 
 
 def test_to_timeseries_shape() -> None:

--- a/tests/test_timeseries_helpers.py
+++ b/tests/test_timeseries_helpers.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import date
+import pandas as pd
 
-from nyc311.dataframes import resample_and_fill, to_panel, to_timeseries
+from nyc311.analysis import extract_topics
+from nyc311.dataframes import (
+    resample_and_fill,
+    to_panel,
+    to_timeseries,
+    to_topic_timeseries,
+)
 from nyc311.io import load_service_requests
 from nyc311.models import TopicQuery
-from nyc311.analysis import extract_topics
 
 FIXTURE_PATH = __import__("pathlib").Path(__file__).parent / "fixtures" / "service_requests_fixture.csv"
 
@@ -26,8 +31,6 @@ def test_to_panel_multiindex() -> None:
 
 
 def test_resample_and_fill() -> None:
-    import pandas as pd
-
     idx = pd.date_range("2024-01-01", periods=3, freq="D")
     df = pd.DataFrame({"a": [1.0, 2.0, 3.0]}, index=idx)
     out = resample_and_fill(df, "2D", method="zero")
@@ -35,8 +38,6 @@ def test_resample_and_fill() -> None:
 
 
 def test_topic_timeseries() -> None:
-    from nyc311.dataframes import to_topic_timeseries
-
     records = load_service_requests(FIXTURE_PATH)
     assignments = extract_topics(records, TopicQuery(complaint_type="Illegal Parking"))
     ts = to_topic_timeseries(assignments, freq="M")

--- a/uv.lock
+++ b/uv.lock
@@ -1530,6 +1530,8 @@ spatial = [
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "pandas-stubs", version = "2.3.3.260113", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas-stubs", version = "3.0.0.260204", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1573,6 +1575,7 @@ provides-extras = ["all", "dataframes", "plotting", "science", "spatial"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.18" },
+    { name = "pandas-stubs", specifier = ">=2.3.0" },
     { name = "pylint", specifier = ">=3.3" },
     { name = "pytest", specifier = ">=9" },
     { name = "pytest-cov", specifier = ">=7" },
@@ -1744,6 +1747,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/a5/2f6ed612056819de445a433ca1f2821ac3dab7f150d569a59e9cc105de1d/pandas-3.0.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:734be7551687c00fbd760dc0522ed974f82ad230d4a10f54bf51b80d44a08702", size = 11815274, upload-time = "2026-03-31T06:48:22.695Z" },
     { url = "https://files.pythonhosted.org/packages/00/2f/b622683e99ec3ce00b0854bac9e80868592c5b051733f2cf3a868e5fea26/pandas-3.0.2-cp314-cp314t-win_amd64.whl", hash = "sha256:57a07209bebcbcf768d2d13c9b78b852f9a15978dac41b9e6421a81ad4cdd276", size = 10888530, upload-time = "2026-03-31T06:48:25.806Z" },
     { url = "https://files.pythonhosted.org/packages/cb/2b/f8434233fab2bd66a02ec014febe4e5adced20e2693e0e90a07d118ed30e/pandas-3.0.2-cp314-cp314t-win_arm64.whl", hash = "sha256:5371b72c2d4d415d08765f32d689217a43227484e81b2305b52076e328f6f482", size = 9455341, upload-time = "2026-03-31T06:48:28.418Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "2.3.3.260113"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.11'",
+]
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "types-pytz", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/5d/be23854a73fda69f1dbdda7bc10fbd6f930bd1fa87aaec389f00c901c1e8/pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800", size = 116131, upload-time = "2026-01-13T22:30:16.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c6/df1fe324248424f77b89371116dab5243db7f052c32cc9fe7442ad9c5f75/pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3", size = 168246, upload-time = "2026-01-13T22:30:15.244Z" },
+]
+
+[[package]]
+name = "pandas-stubs"
+version = "3.0.0.260204"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/1d/297ff2c7ea50a768a2247621d6451abb2a07c0e9be7ca6d36ebe371658e5/pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3", size = 109383, upload-time = "2026-02-04T15:17:17.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/2f/f91e4eee21585ff548e83358332d5632ee49f6b2dcd96cb5dca4e0468951/pandas_stubs-3.0.0.260204-py3-none-any.whl", hash = "sha256:5ab9e4d55a6e2752e9720828564af40d48c4f709e6a2c69b743014a6fcb6c241", size = 168540, upload-time = "2026-02-04T15:17:15.615Z" },
 ]
 
 [[package]]
@@ -2677,6 +2719,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2026.1.1.20260402"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/ff/52b895d4cb5f51f4ae50de8ca6a0b4098a71fa174b63f14d80ba86fa0692/types_pytz-2026.1.1.20260402.tar.gz", hash = "sha256:79209aa51dc003a4a6a764234d92b14e5c09a1b7f24e0f00c493929fd33618e8", size = 10726, upload-time = "2026-04-02T04:17:52.603Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/ce/93d4fc3ba66be6cd50f3f22bbdb6fd953a02689398ea2c4a733e023c9227/types_pytz-2026.1.1.20260402-py3-none-any.whl", hash = "sha256:0d9a60ed1c6ad4fce7c6395b5bd2d9827db41d4b83de7c0322cf85869c2bfda3", size = 10122, upload-time = "2026-04-02T04:17:51.729Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Ruff**: lint + format fixes from earlier iterations.
- **mypy**: typing fixes + `pandas-stubs` in dev.
- **prek / nox lint** (repository hygiene): `end-of-file-fixer` + **Prettier** on markdown — applied to `README.md`, `examples/about-the-data/README.md`, and `examples/about-the-data/reports/about-the-data-tearsheet.md` so CI matches the tree (trailing newline, line wraps, table alignment).

## Reproduce CI lint locally

The workflow runs `uvx nox -s lint -- ...` after Ruff and mypy. Equivalent:

```bash
env -u NO_COLOR -u FORCE_COLOR uvx nox -s lint -- blacken-docs check-added-large-files check-case-conflict check-merge-conflict check-symlinks check-yaml debug-statements end-of-file-fixer mixed-line-ending name-tests-test requirements-txt-fixer trailing-whitespace rst-backticks rst-directive-colons rst-inline-touching-normal prettier codespell shellcheck disallow-caps validate-pyproject check-dependabot check-github-workflows check-readthedocs
```

(Run twice if hooks modify files the first time; the second run should pass.)

**Note:** If both `NO_COLOR=1` and `FORCE_COLOR=0` are set, `nox` can error (`--no-color` and `--force-color`); unset them for nox or use a clean shell.

## Verification

- `nox -s lint` (command above): passed.
- `uv run --frozen ruff check .`, `ruff format --check .`, `mypy`: passed on prior commits (docs-only change here).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0072fff0-d7b7-4484-80eb-021917eca9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0072fff0-d7b7-4484-80eb-021917eca9da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

