### PR TITLE
feat(io): add closed_date to ServiceRequestRecord + bulk_fetch (closes #20)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,24 @@
 
 ### Added
 
+- **`ServiceRequestRecord.closed_date`** (`date | None`, default `None`) —
+  carries the per-complaint resolution-date column through the full ingest /
+  export / dataframe / Socrata pipeline. Fixes [#20][i20]: `bulk_fetch`'s
+  Socrata `$select` now requests `closed_date` alongside `created_date`, the CSV
+  reader and writer both preserve the column, and `records_to_dataframe`
+  surfaces it as a `datetime64`-typed column (with pandas `NaT` ↔ Python `None`
+  round-trip). Consumers doing resolution-time / SLA analysis can compute
+  `record.closed_date - record.created_date` directly instead of bypassing the
+  SDK.
+
+  Schema change is additive: existing call sites that instantiate
+  `ServiceRequestRecord` without `closed_date` keep working; the default `None`
+  models the unresolved-complaint case exactly as Socrata returns it. CSV
+  snapshots written by pre-v1.0.1 SDKs load without `closed_date` too — the CSV
+  column is optional.
+
+[i20]: https://github.com/random-walks/nyc311/issues/20
+
 ### Changed
 
 ### Fixed

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -8,6 +8,12 @@ causal-inference engines on panel data, see
 [factor-factory integration](integration.md). For a before/after diff of
 consumer code from v0.3, see [migration-v0-to-v1.md](migration-v0-to-v1.md).
 
+`ServiceRequestRecord` carries both `created_date` and `closed_date` (added in
+v1.0.1, nullable for unresolved complaints) so resolution-time analyses can
+compute `closed_date - created_date` without bypassing the SDK. All loaders —
+CSV, Socrata, `bulk_fetch`, and the dataframe helpers — preserve `closed_date`
+end-to-end.
+
 The current SDK is built around small, typed steps:
 
 1. load records

--- a/src/nyc311/dataframes/_records.py
+++ b/src/nyc311/dataframes/_records.py
@@ -27,6 +27,7 @@ def records_to_dataframe(records: list[ServiceRequestRecord]) -> Any:
                 "borough": record.borough,
                 "community_district": record.community_district,
                 "resolution_description": record.resolution_description,
+                "closed_date": record.closed_date,
                 "latitude": record.latitude,
                 "longitude": record.longitude,
             }
@@ -36,6 +37,8 @@ def records_to_dataframe(records: list[ServiceRequestRecord]) -> Any:
     )
     if "created_date" in dataframe:
         dataframe["created_date"] = pd.to_datetime(dataframe["created_date"])
+    if "closed_date" in dataframe:
+        dataframe["closed_date"] = pd.to_datetime(dataframe["closed_date"])
     return dataframe
 
 
@@ -66,6 +69,17 @@ def dataframe_to_records(dataframe: Any) -> list[ServiceRequestRecord]:
             if resolution_description in (None, "") or pd.isna(resolution_description)
             else str(resolution_description)
         )
+        raw_closed_date = row.get("closed_date")
+        # pd.isna handles pd.NaT directly; it must come first because
+        # pd.NaT passes isinstance(x, datetime.date).
+        if raw_closed_date is None or pd.isna(raw_closed_date):
+            closed_date: date | None = None
+        elif hasattr(raw_closed_date, "to_pydatetime"):
+            closed_date = raw_closed_date.to_pydatetime().date()
+        elif isinstance(raw_closed_date, date):
+            closed_date = raw_closed_date
+        else:
+            closed_date = date.fromisoformat(str(raw_closed_date))
         latitude = row.get("latitude")
         longitude = row.get("longitude")
         records.append(
@@ -81,6 +95,7 @@ def dataframe_to_records(dataframe: Any) -> list[ServiceRequestRecord]:
                 longitude=None
                 if longitude is None or pd.isna(longitude)
                 else longitude,
+                closed_date=closed_date,
             )
         )
     return records

--- a/src/nyc311/export/_csv.py
+++ b/src/nyc311/export/_csv.py
@@ -82,6 +82,9 @@ def export_service_requests_csv(
                     "borough": row.borough,
                     "community_district": row.community_district,
                     "resolution_description": row.resolution_description or "",
+                    "closed_date": (
+                        "" if row.closed_date is None else row.closed_date.isoformat()
+                    ),
                     "latitude": "" if row.latitude is None else row.latitude,
                     "longitude": "" if row.longitude is None else row.longitude,
                 }

--- a/src/nyc311/export/_tabular.py
+++ b/src/nyc311/export/_tabular.py
@@ -19,6 +19,7 @@ SERVICE_REQUEST_CSV_COLUMNS: Final[tuple[str, ...]] = (
 
 SERVICE_REQUEST_OPTIONAL_COLUMNS: Final[tuple[str, ...]] = (
     "resolution_description",
+    "closed_date",
     "latitude",
     "longitude",
 )

--- a/src/nyc311/io/_csv.py
+++ b/src/nyc311/io/_csv.py
@@ -36,6 +36,19 @@ def _parse_created_date(raw_value: str) -> date:
     return date.fromisoformat(normalized_value)
 
 
+def _parse_optional_date(raw_value: str | None) -> date | None:
+    """Parse an optional NYC 311-style date string into a ``date`` or ``None``.
+
+    Accepts the same ISO shapes as :func:`_parse_created_date` plus
+    empty / ``None`` inputs for unresolved complaints.
+    """
+    if raw_value is None:
+        return None
+    if not raw_value.strip():
+        return None
+    return _parse_created_date(raw_value)
+
+
 def _parse_optional_coordinate(raw_value: str | None) -> float | None:
     if raw_value is None:
         return None
@@ -81,6 +94,7 @@ def _record_from_mapping(
         resolution_description=row.get("resolution_description"),
         latitude=_parse_optional_coordinate(row.get("latitude")),
         longitude=_parse_optional_coordinate(row.get("longitude")),
+        closed_date=_parse_optional_date(row.get("closed_date")),
     )
 
 

--- a/src/nyc311/io/_socrata.py
+++ b/src/nyc311/io/_socrata.py
@@ -17,6 +17,7 @@ from ._filters import _apply_filters
 _SOCRATA_FIELD_ALIASES: Final[dict[str, tuple[str, ...]]] = {
     "unique_key": ("unique_key",),
     "created_date": ("created_date",),
+    "closed_date": ("closed_date",),
     "complaint_type": ("complaint_type",),
     "descriptor": ("descriptor",),
     "borough": ("borough",),
@@ -45,6 +46,7 @@ def _normalize_socrata_row(raw_row: dict[str, object]) -> dict[str, str]:
                 continue
             if canonical_field in {
                 "resolution_description",
+                "closed_date",
                 "latitude",
                 "longitude",
             }:
@@ -63,8 +65,8 @@ def _normalize_socrata_row(raw_row: dict[str, object]) -> dict[str, str]:
 
 def _socrata_select_fields() -> str:
     return (
-        "unique_key, created_date, complaint_type, descriptor, borough, "
-        "community_board, resolution_description, latitude, longitude"
+        "unique_key, created_date, closed_date, complaint_type, descriptor, "
+        "borough, community_board, resolution_description, latitude, longitude"
     )
 
 

--- a/src/nyc311/models/_records.py
+++ b/src/nyc311/models/_records.py
@@ -16,7 +16,17 @@ from ._normalize import (
 
 @dataclass(frozen=True, slots=True)
 class ServiceRequestRecord:
-    """A single loaded NYC 311-style service-request record."""
+    """A single loaded NYC 311-style service-request record.
+
+    .. note::
+
+        As of nyc311 v1.0.1, ``closed_date`` is carried alongside
+        ``created_date`` so resolution-time analyses don't have to
+        bypass the SDK. The field is optional — Socrata returns a
+        null ``closed_date`` for any unresolved complaint — and
+        existing call sites that instantiate the record without it
+        keep working unchanged.
+    """
 
     service_request_id: str
     created_date: date
@@ -27,6 +37,10 @@ class ServiceRequestRecord:
     resolution_description: str | None = None
     latitude: float | None = None
     longitude: float | None = None
+    #: Date the complaint was closed. ``None`` for unresolved
+    #: complaints. Use ``closed_date - created_date`` for resolution
+    #: latency in days.
+    closed_date: date | None = None
 
     def __post_init__(self) -> None:
         if not _normalize_value(self.service_request_id):

--- a/src/nyc311/pipeline.py
+++ b/src/nyc311/pipeline.py
@@ -136,6 +136,16 @@ def bulk_fetch(
     sidecar containing the row count, SHA-256 checksum, fetch
     timestamp, and the filter parameters used.
 
+    The Socrata ``$select`` fragment requests the schema:
+    ``unique_key, created_date, closed_date, complaint_type,
+    descriptor, borough, community_board, resolution_description,
+    latitude, longitude``. ``closed_date`` (added in v1.0.1 per
+    random-walks/nyc311#20) is nullable — unresolved complaints
+    serialize it as an empty column — which lets downstream
+    resolution-time / SLA analyses compute
+    ``closed_date - created_date`` directly without a second
+    round-trip.
+
     Args:
         complaint_types: Optional whitelist of complaint types. When
             empty, every complaint type is included.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -116,6 +116,9 @@ def test_cli_fetch_command_exports_filtered_socrata_snapshot(
             "borough": "BROOKLYN",
             "community_district": "BROOKLYN 01",
             "resolution_description": "Inspection scheduled",
+            # closed_date flows through the Socrata fetch stub too
+            # (the fixture doesn't seed it, so it's an empty string).
+            "closed_date": "",
             "latitude": "40.73",
             "longitude": "-73.96",
         }

--- a/tests/test_closed_date.py
+++ b/tests/test_closed_date.py
@@ -1,0 +1,242 @@
+"""Closed-date coverage — issue #20.
+
+The `closed_date` field shipped in v1.0.1 so resolution-time analyses
+don't have to bypass the SDK. These tests cover the four pipelines
+the bulk_fetch → analysis round-trip touches:
+
+1. `ServiceRequestRecord` constructor accepts closed_date and defaults
+   to ``None`` for unresolved complaints.
+2. Socrata `$select` string includes `closed_date` and the normalizer
+   tolerates its absence from a row.
+3. CSV ingest / export preserves `closed_date` (both the ISO date
+   string and the empty-string-for-None convention).
+4. DataFrame round-trip preserves the column, datetime dtype, and NaT
+   ↔ None bridging.
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from nyc311.export._csv import export_service_requests_csv
+from nyc311.io._csv import (
+    _parse_optional_date,
+    _record_from_mapping,
+    load_service_requests_from_csv,
+)
+from nyc311.io._socrata import _normalize_socrata_row, _socrata_select_fields
+from nyc311.models import ExportTarget, ServiceRequestFilter, ServiceRequestRecord
+
+# ---------------------------------------------------------------------------
+# 1. Record model
+# ---------------------------------------------------------------------------
+
+
+def test_record_defaults_closed_date_to_none() -> None:
+    record = ServiceRequestRecord(
+        service_request_id="SR-NULL",
+        created_date=date(2025, 1, 1),
+        complaint_type="Rodent",
+        descriptor="Rat sighting",
+        borough="BRONX",
+        community_district="BRONX 01",
+    )
+    assert record.closed_date is None
+
+
+def test_record_resolution_latency_in_days() -> None:
+    record = ServiceRequestRecord(
+        service_request_id="SR-CLOSED",
+        created_date=date(2025, 1, 1),
+        complaint_type="Rodent",
+        descriptor="Rat sighting",
+        borough="BRONX",
+        community_district="BRONX 01",
+        resolution_description="Inspected",
+        closed_date=date(2025, 1, 9),
+    )
+    assert record.closed_date is not None
+    assert (record.closed_date - record.created_date).days == 8
+
+
+# ---------------------------------------------------------------------------
+# 2. Socrata select + normalizer
+# ---------------------------------------------------------------------------
+
+
+def test_socrata_select_includes_closed_date() -> None:
+    assert "closed_date" in _socrata_select_fields()
+
+
+def test_socrata_normalizer_tolerates_missing_closed_date() -> None:
+    row: dict[str, object] = {
+        "unique_key": "SR-MISSING",
+        "created_date": "2025-01-01T00:00:00.000",
+        # closed_date omitted — Socrata returns null for unresolved
+        "complaint_type": "Rodent",
+        "descriptor": "Rat sighting",
+        "borough": "BRONX",
+        "community_board": "BRONX 01",
+    }
+    normalized = _normalize_socrata_row(row)
+    assert "closed_date" not in normalized
+
+
+def test_socrata_normalizer_passes_through_closed_date() -> None:
+    row: dict[str, object] = {
+        "unique_key": "SR-CLOSED",
+        "created_date": "2025-01-01T00:00:00.000",
+        "closed_date": "2025-01-09T08:15:00.000",
+        "complaint_type": "Rodent",
+        "descriptor": "Rat sighting",
+        "borough": "BRONX",
+        "community_board": "BRONX 01",
+    }
+    normalized = _normalize_socrata_row(row)
+    assert normalized["closed_date"] == "2025-01-09T08:15:00.000"
+
+
+# ---------------------------------------------------------------------------
+# 3. CSV ingest / export
+# ---------------------------------------------------------------------------
+
+
+def test_parse_optional_date_roundtrip() -> None:
+    assert _parse_optional_date(None) is None
+    assert _parse_optional_date("") is None
+    assert _parse_optional_date("   ") is None
+    assert _parse_optional_date("2025-01-09") == date(2025, 1, 9)
+    assert _parse_optional_date("2025-01-09T08:15:00.000Z") == date(2025, 1, 9)
+
+
+def test_record_from_mapping_handles_closed_date_column() -> None:
+    row = {
+        "unique_key": "SR-CLOSED",
+        "created_date": "2025-01-01",
+        "closed_date": "2025-01-09",
+        "complaint_type": "Rodent",
+        "descriptor": "Rat sighting",
+        "borough": "BRONX",
+        "community_board": "BRONX 01",
+    }
+    record = _record_from_mapping(row, community_district_column="community_board")
+    assert record.closed_date == date(2025, 1, 9)
+
+
+def test_record_from_mapping_without_closed_date_column() -> None:
+    row = {
+        "unique_key": "SR-OPEN",
+        "created_date": "2025-01-01",
+        "complaint_type": "Rodent",
+        "descriptor": "Rat sighting",
+        "borough": "BRONX",
+        "community_board": "BRONX 01",
+    }
+    record = _record_from_mapping(row, community_district_column="community_board")
+    assert record.closed_date is None
+
+
+def test_csv_export_emits_closed_date_column(tmp_path: Path) -> None:
+    records = [
+        ServiceRequestRecord(
+            service_request_id="SR-1",
+            created_date=date(2025, 1, 1),
+            complaint_type="Rodent",
+            descriptor="Rat",
+            borough="BRONX",
+            community_district="BRONX 01",
+            closed_date=date(2025, 1, 9),
+        ),
+        ServiceRequestRecord(
+            service_request_id="SR-2",
+            created_date=date(2025, 1, 2),
+            complaint_type="Rodent",
+            descriptor="Rat",
+            borough="BRONX",
+            community_district="BRONX 01",
+            # closed_date intentionally omitted — unresolved
+        ),
+    ]
+    output_path = tmp_path / "export.csv"
+    export_service_requests_csv(records, ExportTarget("csv", output_path))
+
+    with output_path.open(newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    assert "closed_date" in rows[0]
+    assert rows[0]["closed_date"] == "2025-01-09"
+    assert rows[1]["closed_date"] == ""
+
+
+def test_csv_round_trip_preserves_closed_date(tmp_path: Path) -> None:
+    original = [
+        ServiceRequestRecord(
+            service_request_id="SR-1",
+            created_date=date(2025, 1, 1),
+            complaint_type="Rodent",
+            descriptor="Rat",
+            borough="BRONX",
+            community_district="BRONX 01",
+            closed_date=date(2025, 1, 9),
+        ),
+        ServiceRequestRecord(
+            service_request_id="SR-2",
+            created_date=date(2025, 1, 2),
+            complaint_type="Rodent",
+            descriptor="Rat",
+            borough="BRONX",
+            community_district="BRONX 01",
+        ),
+    ]
+    csv_path = tmp_path / "round_trip.csv"
+    export_service_requests_csv(original, ExportTarget("csv", csv_path))
+
+    loaded = load_service_requests_from_csv(csv_path, filters=ServiceRequestFilter())
+
+    assert loaded == original
+    assert loaded[0].closed_date == date(2025, 1, 9)
+    assert loaded[1].closed_date is None
+
+
+# ---------------------------------------------------------------------------
+# 4. DataFrame round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.optional
+def test_dataframe_round_trip_preserves_closed_date() -> None:
+    pd = pytest.importorskip("pandas")
+    from nyc311.dataframes import dataframe_to_records, records_to_dataframe
+
+    original = [
+        ServiceRequestRecord(
+            service_request_id="SR-1",
+            created_date=date(2025, 1, 1),
+            complaint_type="Rodent",
+            descriptor="Rat",
+            borough="BRONX",
+            community_district="BRONX 01",
+            closed_date=date(2025, 1, 9),
+        ),
+        ServiceRequestRecord(
+            service_request_id="SR-2",
+            created_date=date(2025, 1, 2),
+            complaint_type="Rodent",
+            descriptor="Rat",
+            borough="BRONX",
+            community_district="BRONX 01",
+        ),
+    ]
+
+    df = records_to_dataframe(original)
+    assert "closed_date" in df.columns
+    assert str(df["closed_date"].dtype).startswith("datetime64")
+    # NaT bridges back to Python None on the round-trip.
+    assert pd.isna(df["closed_date"].iloc[1])
+
+    round_tripped = dataframe_to_records(df)
+    assert round_tripped == original

--- a/tests/test_dataframes.py
+++ b/tests/test_dataframes.py
@@ -28,6 +28,7 @@ def test_records_dataframe_round_trip_preserves_core_fields() -> None:
         "borough",
         "community_district",
         "resolution_description",
+        "closed_date",
         "latitude",
         "longitude",
     ]

--- a/tests/test_exporters.py
+++ b/tests/test_exporters.py
@@ -89,6 +89,8 @@ def test_export_service_requests_csv_writes_snapshot_rows(tmp_path: Path) -> Non
         "borough": "BROOKLYN",
         "community_district": "BROOKLYN 01",
         "resolution_description": "Officers advised occupants to lower music",
+        # closed_date is optional; the packaged sample fixture has no value.
+        "closed_date": "",
         "latitude": "40.73",
         "longitude": "-73.96",
     }


### PR DESCRIPTION
## Summary

Fixes #20. The blaise-website `showcase-resolution-equity` case study had to bypass the SDK and hit Socrata directly because `bulk_fetch`'s `$select` omitted `closed_date`, and `ServiceRequestRecord` didn't carry the field. That gap silently blocked any resolution-time / response-latency analysis.

This PR adds `closed_date: date | None` to `ServiceRequestRecord` and propagates it through all four load-bearing pipelines:

- **Socrata** — `_socrata_select_fields()` requests `closed_date`, `_SOCRATA_FIELD_ALIASES` learns it, and `_normalize_socrata_row` treats it as optional (same bucket as `resolution_description` / `latitude` / `longitude`, which Socrata also returns `null` for on unresolved rows).
- **CSV reader** — `_record_from_mapping` parses `closed_date` via a new `_parse_optional_date` helper (handles `None`, `""`, whitespace, ISO date, Socrata `T00:00:00.000` timestamps).
- **CSV writer** — `export_service_requests_csv` emits the column (`""` for `None`).
- **DataFrames** — `records_to_dataframe` casts to `datetime64` dtype; `dataframe_to_records` bridges pandas `NaT` ↔ Python `None` (the `isinstance(x, date)` check had to come *after* `pd.isna` because `NaT` is an instance of `datetime.datetime` which is a subclass of `datetime.date`).

Consumers can now do:

```python
records = load_service_requests("data.csv")
for r in records:
    if r.closed_date is not None:
        latency = (r.closed_date - r.created_date).days
```

…instead of bypassing the SDK entirely.

## Schema change is additive

- `ServiceRequestRecord.closed_date` defaults to `None`. Every existing call site that instantiates the record without the field keeps working.
- CSV column is optional. Pre-v1.0.1 CSV snapshots load without it; fresh snapshots written by this SDK include it. No migration needed.
- Socrata `$select` now requests `closed_date` for free on every `bulk_fetch` — zero cost for consumers who don't use it (one extra nullable column).

## Tests

Dedicated `tests/test_closed_date.py` with **11 cases**, covering:

1. Record-model default (`None`) + resolution-latency subtraction.
2. Socrata `$select` includes the field; normalizer tolerates missing value + passes through present value.
3. `_parse_optional_date` roundtrip over None / `""` / whitespace / ISO date / Socrata timestamp.
4. `_record_from_mapping` handles all three CSV shapes (column present with value, column absent, column present but empty).
5. CSV export emits the column + serializes `None` as `""`.
6. Full CSV round-trip (export → load) preserves the field.
7. DataFrame round-trip preserves dtype + bridges `NaT` ↔ `None` correctly.

Three existing tests updated for the new column:
- `tests/test_cli.py::test_cli_fetch_command_exports_filtered_socrata_snapshot`
- `tests/test_dataframes.py::test_records_dataframe_round_trip_preserves_core_fields`
- `tests/test_exporters.py::test_export_service_requests_csv_writes_snapshot_rows`

All 234 tests pass (+11 new, +0 failed, 2 documented xfails unchanged).

## Docs

- `bulk_fetch` docstring now lists the full schema + calls out that `closed_date` is nullable (for unresolved complaints) + references this issue.
- `docs/sdk.md` gains a short paragraph near the top explaining the resolution-latency use case.
- `docs/changelog.md` `[Unreleased] → Added` entry with the full "additive, backwards-compatible, fixes #20" narrative.

## Checklist

- [x] `ruff check` + `ruff format --check` + `mypy --strict` + `pylint -E` + public-API audit green
- [x] `pytest -m "not integration"` green (234 passed, 1 skipped, 2 xfailed)
- [x] `mkdocs build --strict` clean
- [x] Pre-commit hygiene hooks idempotent locally (prettier, blacken-docs, end-of-file-fixer, trailing-whitespace, codespell)
- [x] CHANGELOG `[Unreleased]` entry under `### Added`
- [x] Docstring updated on touched public API (`bulk_fetch`)
- [x] No bridge touches (factor-compat-auditor not required)

## Next release

This is a **patch bump** per `.claude/skills/release-bump.md` — net-new public field on an existing dataclass (additive), no breaking changes. Target: **v1.0.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)