### PR TITLE
chore(deps): widen nyc-geo-toolkit pin to >=0.3,<0.5 for upstream v0.4.0

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,36 @@
 
 ### Added
 
+### Changed
+
+- **Widen the `nyc-geo-toolkit` pin** from `>=0.3.0,<0.4` to `>=0.3.0,<0.5` so
+  consumers can pick up the just-shipped [nyc-geo-toolkit v0.4.0][ngt040]
+  alongside nyc311. The upstream v0.4.0 release adds a shapely-backed
+  :func:`nyc_geo_toolkit.centroids_from_boundaries` helper (closing
+  [random-walks/nyc-geo-toolkit#12][ngt12]). nyc311's own homegrown
+  `nyc311.temporal.centroids_from_boundaries` is the shapely-free path and stays
+  as-is with a new `.. note::` cross-reference in its docstring explaining when
+  to use which — the two return different shapes (dict vs BoundaryCollection) on
+  purpose.
+
+[ngt040]: https://github.com/random-walks/nyc-geo-toolkit/releases/tag/v0.4.0
+[ngt12]: https://github.com/random-walks/nyc-geo-toolkit/issues/12
+
+### Fixed
+
+### Deprecated
+
+### Contracts
+
+### Security
+
+## 1.0.1 - 2026-04-20
+
+Patch release. Fixes [#20][i20] — resolution-time / SLA analyses no longer have
+to bypass the SDK.
+
+### Added
+
 - **`ServiceRequestRecord.closed_date`** (`date | None`, default `None`) —
   carries the per-complaint resolution-date column through the full ingest /
   export / dataframe / Socrata pipeline. Fixes [#20][i20]: `bulk_fetch`'s
@@ -21,16 +51,6 @@
   column is optional.
 
 [i20]: https://github.com/random-walks/nyc311/issues/20
-
-### Changed
-
-### Fixed
-
-### Deprecated
-
-### Contracts
-
-### Security
 
 ## 1.0.0 - 2026-04-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "nyc-geo-toolkit>=0.3.0,<0.4",
+  "nyc-geo-toolkit>=0.3.0,<0.5",
   "factor-factory>=1.0.2,<2",
 ]
 

--- a/src/nyc311/temporal/_spatial_weights.py
+++ b/src/nyc311/temporal/_spatial_weights.py
@@ -94,6 +94,25 @@ def centroids_from_boundaries(boundaries: Any) -> dict[str, tuple[float, float]]
     coordinates. This is approximate but cheap and avoids a hard
     dependency on shapely.
 
+    .. note::
+
+        As of nyc-geo-toolkit v0.4.0,
+        :func:`nyc_geo_toolkit.centroids_from_boundaries` is available
+        as a shapely-backed, publication-grade centroid helper — it
+        returns a :class:`BoundaryCollection` of GeoJSON ``Point``
+        features at either the geometric centroid (default) or
+        shapely's ``representative_point`` (guaranteed to lie inside
+        concave polygons such as NYC's jagged community districts).
+        Prefer it when you already have shapely installed and need
+        defensible geometry for a published analysis.
+
+        nyc311's helper is intentionally the **shapely-free** path
+        (returns a plain ``dict[str, (lat, lon)]`` suitable for
+        feeding directly into :func:`build_distance_weights`) and is
+        preserved for workflows that need to stay on the lean base
+        install. The two helpers return different shapes and slightly
+        different numbers; don't swap them mid-analysis.
+
     Args:
         boundaries: A boundary collection exposing a ``features``
             iterable. Each feature must provide a ``geometry`` mapping

--- a/uv.lock
+++ b/uv.lock
@@ -2244,11 +2244,11 @@ wheels = [
 
 [[package]]
 name = "nyc-geo-toolkit"
-version = "0.3.0"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/21/6d/9769c73c3255ce78e54367558a4c78d1f317c679f86260db4395fc1a1759/nyc_geo_toolkit-0.3.0.tar.gz", hash = "sha256:103a96975bbb9e73e8679b5a020ee15810bdf20e83276bfc5d0caf8b5e5da814", size = 11557524, upload-time = "2026-04-19T22:33:36.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/f8/633d2bc86e2472ebbf447666308231bdf7bd31f88244f7f3f1009168f625/nyc_geo_toolkit-0.4.0.tar.gz", hash = "sha256:d44d191724138bc97324fcca0ce7b6ec06ef96ffade6df3d178482c8bf46a810", size = 11559086, upload-time = "2026-04-20T23:16:57.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/b2/25e40c383dd0fd1e70aad95b12264f9cd6fbb5b2535f6abdc0e6da6f9a5b/nyc_geo_toolkit-0.3.0-py3-none-any.whl", hash = "sha256:1ba543bbfc2e97997c8a73b1853ea8827581047eb1ff81cfd9aeed1f8b824ee2", size = 10545685, upload-time = "2026-04-19T22:33:33.236Z" },
+    { url = "https://files.pythonhosted.org/packages/56/37/3f54f92faae36cb32882f47c30522b9d409838b9b11503a9d151d64aeff0/nyc_geo_toolkit-0.4.0-py3-none-any.whl", hash = "sha256:8e2f1b63e2a9a132e285e30a63f68424ff973cbd297d0a31fa13ce60ebae8f7a", size = 10546426, upload-time = "2026-04-20T23:16:54.113Z" },
 ]
 
 [[package]]
@@ -2354,7 +2354,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'all'", specifier = ">=3.10.8" },
     { name = "matplotlib", marker = "extra == 'plotting'", specifier = ">=3.10.8" },
     { name = "matplotlib", marker = "extra == 'science'", specifier = ">=3.10.8" },
-    { name = "nyc-geo-toolkit", specifier = ">=0.3.0,<0.4" },
+    { name = "nyc-geo-toolkit", specifier = ">=0.3.0,<0.5" },
     { name = "pandas", marker = "extra == 'all'", specifier = ">=2.3.3" },
     { name = "pandas", marker = "extra == 'dataframes'", specifier = ">=2.3.3" },
     { name = "pandas", marker = "extra == 'science'", specifier = ">=2.3.3" },


### PR DESCRIPTION
## Summary

nyc-geo-toolkit v0.4.0 shipped 2026-04-20 with a shapely-backed `centroids_from_boundaries` helper (closing [random-walks/nyc-geo-toolkit#12](https://github.com/random-walks/nyc-geo-toolkit/issues/12)). Our previous pin `>=0.3.0,<0.4` blocks consumers from installing nyc-geo-toolkit 0.4.0 alongside nyc311 — a real footgun for blaise-website's `showcase-resolution-equity`, which has an `AUDIT.md §5` workaround using hash-placed CB centroids that can now retire.

Widen the pin to `>=0.3.0,<0.5`. Additive, backwards-compatible.

## Why this doesn't touch `nyc311.temporal.centroids_from_boundaries`

The two helpers **return different shapes on purpose**:

| | nyc311.temporal | nyc_geo_toolkit (v0.4+) |
|---|---|---|
| Return type | `dict[str, (lat, lon)]` | `BoundaryCollection` (Point features) |
| Algorithm | Mean of exterior-ring coords | `shapely.Geometry.centroid` / `representative_point` |
| Deps | Zero — works on base install | Requires `nyc-geo-toolkit[spatial]` + shapely |
| Intended use | Feed directly into `build_distance_weights` | Publication-grade geometry |
| Precision | Crude approximation, concave-polygon bias | Proper geometric centroid |

Swapping them mid-analysis would shift the numbers in case studies. The nyc311 helper gains a `.. note::` cross-reference explaining when to prefer which, and the homegrown version stays as-is for shapely-free workflows.

## Changes

- `pyproject.toml` — `nyc-geo-toolkit>=0.3.0,<0.5` (was `<0.4`)
- `uv.lock` — regenerated, picks up 0.4.0
- `src/nyc311/temporal/_spatial_weights.py` — `.. note::` block on the homegrown helper
- `docs/changelog.md` — `[Unreleased] → Changed` entry + promoted the closed_date content from Unreleased into a proper `## 1.0.1 - 2026-04-20` section (that content shipped as v1.0.1 earlier today)

## Preflight

- `ruff check` + `ruff format --check` + `mypy --strict` + public-API audit: clean
- `pytest -m "not integration"` against nyc-geo-toolkit 0.4.0: **234 passed**, 1 skipped, 2 documented xfails
- `mkdocs build --strict`: clean
- `prek run --all-files` (prettier, blacken-docs, end-of-file-fixer, trailing-whitespace, codespell): idempotent

## Next release

**v1.0.2 patch** — per `.claude/skills/release-bump.md`: dep-pin widening is patch-level. The docstring note is the only source change and it's additive.

Downstream signal: after merge + v1.0.2 release, the blaise-website `showcase-resolution-equity` can drop the hash-placed-CB-centroid workaround in favor of `from nyc_geo_toolkit import centroids_from_boundaries`. Comment heading to PR #19 there once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)