### PR TITLE
docs(post-1.0.2): llms.txt + v1.0.1/v1.0.2 doc fill-in + closed_date demo in quickstart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,23 @@ against your diff.
 **For agents cutting a release**: read [`docs/releasing.md`](docs/releasing.md)
 and [`.claude/skills/release-bump.md`](.claude/skills/release-bump.md).
 
+**For LLMs / agentic tools** discovering this repo cold:
+[`docs/llms.txt`](docs/llms.txt) is the canonical machine-readable
+[llmstxt.org](https://llmstxt.org)-style summary of the public surface, typical
+workflows, contracts, and ecosystem position.
+
+## Current release line
+
+- **v1.0.2** (2026-04-20) — patch widening `nyc-geo-toolkit` pin to
+  `>=0.3.0,<0.5` for upstream v0.4.0's shapely-backed
+  `centroids_from_boundaries` (the homegrown `nyc311.temporal` helper stays
+  as-is, shapely-free, with a docstring cross-reference).
+- **v1.0.1** (2026-04-20) — patch adding `ServiceRequestRecord.closed_date`
+  through the full Socrata / CSV / dataframe pipeline. Resolution-time analysis
+  no longer needs to bypass the SDK.
+- **v1.0.0** (2026-04-19) — first major. factor-factory integration, Claude Code
+  infra, jellycell tearsheets, four bundled case studies, Python 3.12+ floor.
+
 ## Hard rules
 
 - **The two factor-factory bridges are additive contracts**. Renaming or

--- a/README.md
+++ b/README.md
@@ -92,6 +92,29 @@ bundled case studies:
 pip install "nyc311[tearsheets]"
 ```
 
+### v1.0.1 — `ServiceRequestRecord.closed_date`
+
+Resolution-time / SLA analyses don't need to bypass the SDK any more.
+`bulk_fetch`'s Socrata `$select` now requests `closed_date` by default, the CSV
+reader and writer preserve it, and `records_to_dataframe` surfaces it as a
+`datetime64[ns]` column (with `NaT` for unresolved complaints):
+
+```python
+records = io.load_service_requests("data/cache/noise-2020-2024.csv")
+resolved = [r for r in records if r.closed_date is not None]
+mean_latency_days = sum((r.closed_date - r.created_date).days for r in resolved) / len(
+    resolved
+)
+```
+
+### v1.0.2 — `nyc-geo-toolkit>=0.3,<0.5` pin widened
+
+Pulls in upstream's shapely-backed `nyc_geo_toolkit.centroids_from_boundaries` —
+useful when the lean shapely-free `nyc311.temporal.centroids_from_boundaries`
+(which returns a `dict[str, (lat, lon)]` and feeds `build_distance_weights`)
+isn't publication-grade enough. See the docstring `.. note::` for the decision
+table on which to pick.
+
 ## Install
 
 Choose the dependency footprint that matches your workflow:

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -142,14 +142,14 @@ for each case study:
 Each case study ships a `jellycell.toml` alongside its `run_analysis.py` so
 `uv run jellycell render` works in-place.
 
-## Version ranges
+## Version ranges (v1.0.2)
 
-| Package           | v1.0.0 pin                             |
-| ----------------- | -------------------------------------- |
-| `factor-factory`  | `>=1.0.2,<2`                           |
-| `jellycell`       | `>=1.3.5,<2` (via `tearsheets` extra)  |
-| `nyc-geo-toolkit` | `>=0.3.0,<0.4`                         |
-| Python            | `>=3.12` (dropped 3.10/3.11 in v1.0.0) |
+| Package           | Pin                                               |
+| ----------------- | ------------------------------------------------- |
+| `factor-factory`  | `>=1.0.2,<2`                                      |
+| `jellycell`       | `>=1.3.5,<2` (via `tearsheets` extra)             |
+| `nyc-geo-toolkit` | `>=0.3.0,<0.5` (widened v1.0.2 for upstream v0.4) |
+| Python            | `>=3.12` (dropped 3.10/3.11 in v1.0.0)            |
 
 Follow the
 [factor-factory roadmap](https://github.com/random-walks/factor-factory/blob/main/docs/og_context/06_post_v0.1_roadmap.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,82 @@
+# nyc311
+
+> Reproducible Python toolkit for NYC 311 complaint analysis — typed SDK + thin CLI, composable factor pipelines, balanced temporal panels, 17 statistical modules, and additive adapters into factor-factory's 17 causal-inference engine families. Optional jellycell tearsheets for publication-grade case-study reports.
+
+Authored by Blaise Albis-Burdige (<https://blaiseab.com>). MIT-licensed. Python ≥ 3.12.
+
+Sits downstream of [`nyc-geo-toolkit`](https://github.com/random-walks/nyc-geo-toolkit) (geographic primitives) and [`factor-factory`](https://github.com/random-walks/factor-factory) (causal-inference engines). Optionally consumes [`jellycell`](https://github.com/random-walks/jellycell) via the `tearsheets` extra.
+
+## Docs
+
+- [Home](https://nyc311.readthedocs.io/en/latest/): project overview + install
+- [Getting Started](https://nyc311.readthedocs.io/en/latest/getting-started/): fastest path to a useful run
+- [SDK Guide](https://nyc311.readthedocs.io/en/latest/sdk/): composable SDK patterns, `records_to_dataframe`, factor pipelines, temporal panels, resolution-time analysis
+- [CLI Reference](https://nyc311.readthedocs.io/en/latest/cli/): `nyc311 fetch` + `nyc311 topics` subcommands
+- [factor-factory integration](https://nyc311.readthedocs.io/en/latest/integration/): `PanelDataset.to_factor_factory_panel()` + `Pipeline.as_factor_factory_estimate()` — the two load-bearing bridges
+- [Migration v0 → v1](https://nyc311.readthedocs.io/en/latest/migration-v0-to-v1/): consumer upgrade path, before/after snippets
+- [Architecture](https://nyc311.readthedocs.io/en/latest/architecture/): module responsibilities + mermaid pipeline diagram
+- [Examples](https://nyc311.readthedocs.io/en/latest/examples/): case-study + showcase index
+- [Changelog](https://nyc311.readthedocs.io/en/latest/changelog/): per-release detail
+
+## Public surfaces
+
+- `nyc311.models`: typed dataclasses — `ServiceRequestRecord` (carries `created_date`, `closed_date`, `resolution_description`, `lat/lon`), `ServiceRequestFilter`, `GeographyFilter`, `SocrataConfig`, `ExportTarget`, `TopicQuery`, `AnalysisWindow`, borough constants.
+- `nyc311.io`: `load_service_requests_from_csv`, `load_service_requests` (dispatches CSV or Socrata), `cached_fetch`.
+- `nyc311.pipeline`: `fetch_service_requests`, `run_topic_pipeline`, `bulk_fetch` (per-borough CSV + `.meta.json` sidecars).
+- `nyc311.analysis`: `extract_topics`, `aggregate_by_geography`, `analyze_topic_coverage`, `analyze_resolution_gaps`, `detect_anomalies`.
+- `nyc311.export`: `export_topic_table`, `export_anomalies`, `export_geojson`, `export_report_card`, `export_service_requests_csv`.
+- `nyc311.dataframes`: optional pandas helpers — `records_to_dataframe`, `dataframe_to_records`, plus assignment / summary / gap / anomaly / coverage variants.
+- `nyc311.geographies`: thin compatibility layer over `nyc-geo-toolkit`, plus sample boundary loaders.
+- `nyc311.samples`: packaged sample fixtures — `load_sample_service_requests`, `load_sample_boundaries`.
+- `nyc311.factors`: composable factor pipeline. `Pipeline.add()` / `.run()` / `.as_factor_factory_estimate()`. Built-in factors: `ComplaintVolumeFactor`, `ResolutionTimeFactor`, `TopicConcentrationFactor`, `SeasonalityFactor`, `AnomalyScoreFactor`, `ResponseRateFactor`, `RecurrenceFactor`, `SpatialLagFactor`, `EquityGapFactor`.
+- `nyc311.temporal`: `PanelDataset`, `PanelObservation`, `TreatmentEvent`, `build_complaint_panel`, `build_distance_weights`, `centroids_from_boundaries` (shapely-free dict), `weights_to_pysal`, `PanelDataset.to_factor_factory_panel` (adapter to `factor_factory.tidy.Panel`).
+- `nyc311.stats`: 17 statistical modules — ITS, PELT changepoints, STL decomposition, spatial Moran's I / LISA, panel FE/RE, synthetic control, staggered DiD (Callaway-Sant'Anna), event study, RDD (CCT), spatial lag / error, GWR, Theil + Oaxaca-Blinder, reporting-bias EM, Hawkes, BYM2 small-area, STL anomaly, power analysis. Eleven of the seventeen cross-reference a factor-factory equivalent as the preferred backend.
+
+## Typical workflows
+
+- **Load a CSV snapshot, extract topics, aggregate, export**: `load_service_requests` → `extract_topics` → `aggregate_by_geography` → `export_topic_table`.
+- **Live Socrata fetch with filtered $select (includes `closed_date` since v1.0.1)**: `pipeline.fetch_service_requests(filters=..., socrata_config=...)` or the per-borough `pipeline.bulk_fetch(start_date=, end_date=)` for multi-year extracts.
+- **Resolution-time analysis**: `record.closed_date - record.created_date` directly on each `ServiceRequestRecord` (unresolved → `closed_date is None`).
+- **Balanced panels + treatment events**: `build_complaint_panel(records, geography="community_district", freq="ME", treatment_events=...)` → `PanelDataset`.
+- **Causal inference via factor-factory**: `panel.to_factor_factory_panel()` → `factor_factory.engines.<family>.estimate(...)`. Families: `did`, `sdid`, `scm`, `mediation`, `rdd`, `changepoint`, `stl`, `panel_reg`, `inequality`, `spatial`, `reporting_bias`, `hawkes`, `survival`, `event_study`, `het_te`, `dml`, `climate`, `diffusion`.
+- **Publication-grade tearsheets** (opt-in via `nyc311[tearsheets]`): each case study's `run_analysis.py` emits `manuscripts/{METHODOLOGY,DIAGNOSTICS_CHECKLIST,FINDINGS,MANUSCRIPT,AUDIT}.md` via `factor_factory.jellycell.tearsheets.*`.
+
+## Contracts
+
+- `ServiceRequestRecord.closed_date` (added v1.0.1): `date | None`, defaults to `None`. Round-trips through CSV ingest / export / dataframe / Socrata as `datetime64[ns]` with pandas `NaT` ↔ Python `None`.
+- `PanelDataset.to_factor_factory_panel(*, outcome_col, provenance, spatial_weights) -> factor_factory.tidy.Panel` (added v1.0.0): public additive contract. Any kwarg rename or removal is a major bump.
+- `Pipeline.as_factor_factory_estimate(panel, *, family, method, outcome, **engine_kwargs)` (added v1.0.0): public additive contract. Same rule.
+
+## Install
+
+- `pip install nyc311` — base SDK + CLI + CSV / Socrata loaders.
+- `pip install "nyc311[all]"` — full turnkey stack (pandas, geopandas, matplotlib, stats, tearsheets).
+- Individual extras: `[dataframes]`, `[spatial]`, `[plotting]`, `[science]`, `[stats]`, `[bayes]`, `[tearsheets]`.
+
+## Examples (tracked in repo)
+
+- `examples/case_studies/rat_containerization/`: 2024 NYC rat-containerization mandate evaluation using nyc311's full causal-inference surface (SCM, staggered DiD, event study, RDD).
+- `examples/case_studies/resolution_equity/`: 5-year NYC 311 resolution-equity longitudinal study (STL, PELT changepoints, panel FE, Moran's I / LISA, Theil, Oaxaca-Blinder, reporting-bias EM).
+- `examples/sdid-multi-borough-policy/`: synthetic Synthetic-DiD showcase via factor-factory.
+- `examples/mediation-cascade-resolution/`: synthetic four-way mediation decomposition via factor-factory.
+- `examples/factor-factory-quickstart/`: 50-line no-jellycell showcase of `PanelDataset → factor_factory.tidy.Panel → engine → pandas`.
+
+## Version ranges (v1.0.2)
+
+- `nyc-geo-toolkit>=0.3.0,<0.5` (widened in v1.0.2 to allow upstream v0.4.0's shapely-backed `centroids_from_boundaries`)
+- `factor-factory>=1.0.2,<2`
+- `jellycell>=1.3.5,<2` (via `tearsheets` extra)
+- Python `>=3.12`
+
+## Release history
+
+- v1.0.2 (2026-04-20): widen `nyc-geo-toolkit` pin to `>=0.3.0,<0.5`.
+- v1.0.1 (2026-04-20): `ServiceRequestRecord.closed_date` through Socrata / CSV / dataframe pipelines.
+- v1.0.0 (2026-04-19): factor-factory integration, Claude Code infra, jellycell tearsheets, four bundled case studies, Python 3.12+ floor.
+
+## See also
+
+- [`random-walks/factor-factory`](https://github.com/random-walks/factor-factory): causal-inference engine framework
+- [`random-walks/jellycell`](https://github.com/random-walks/jellycell): reporting / tearsheet library
+- [`random-walks/nyc-geo-toolkit`](https://github.com/random-walks/nyc-geo-toolkit): geographic primitives
+- [`random-walks/subway-access`](https://github.com/random-walks/subway-access): companion 311-adjacent transit accessibility toolkit

--- a/docs/migration-v0-to-v1.md
+++ b/docs/migration-v0-to-v1.md
@@ -145,6 +145,70 @@ Nothing is deprecated in v1.0.0. A future minor may deprecate specific
 `nyc311.stats` methods in favor of the factor-factory equivalent, but only with
 a full deprecation cycle (two minors of warning before removal).
 
+## v1.0.1 + v1.0.2 addenda
+
+Two patch releases landed same-week as v1.0.0 in response to downstream
+dogfooding signal. Both are **strictly additive**, no consumer code needs to
+change, but you can opt into two small API improvements:
+
+### `ServiceRequestRecord.closed_date` (v1.0.1, see [#20](https://github.com/random-walks/nyc311/issues/20))
+
+`closed_date: date | None` is now a first-class field on the record, carried
+end-to-end through CSV ingest / export, dataframe helpers, and the Socrata
+`$select`. Unresolved complaints surface as `None` (pandas `NaT` in
+`datetime64[ns]` columns). Resolution-time analysis becomes a one-liner:
+
+```python
+# Before — had to bypass the SDK and hit Socrata directly
+import aiohttp
+
+async with aiohttp.ClientSession() as session:
+    ...  # manual $select=..., closed_date + pagination
+```
+
+```python
+# After
+from nyc311 import io, models
+
+records = io.load_service_requests(
+    "data/cache/noise-2020-2024.csv",
+    filters=models.ServiceRequestFilter(complaint_types=("Noise - Residential",)),
+)
+resolved = [r for r in records if r.closed_date is not None]
+latencies = [(r.closed_date - r.created_date).days for r in resolved]
+```
+
+CSV snapshots written by pre-v1.0.1 SDKs load without the column (it's
+optional); fresh snapshots written by v1.0.1+ include it.
+
+### `nyc-geo-toolkit>=0.3.0,<0.5` pin (v1.0.2)
+
+The pin widened to allow installing
+[nyc-geo-toolkit v0.4.0](https://github.com/random-walks/nyc-geo-toolkit/releases/tag/v0.4.0)
+alongside nyc311. Upstream v0.4.0 adds a shapely-backed
+`centroids_from_boundaries` helper that returns a `BoundaryCollection` of
+GeoJSON `Point` features with optional `representative_point=True` for
+non-convex polygons (useful for NYC's jagged community districts).
+
+nyc311's own `nyc311.temporal.centroids_from_boundaries` stays as-is — it's the
+shapely-free path, returns `dict[str, (lat, lon)]`, and feeds directly into
+`build_distance_weights`. Don't swap them mid-analysis (the two return different
+shapes and slightly different numbers). See the cross-reference note in that
+function's docstring for the full decision table.
+
+For publication-grade geometry:
+
+```python
+from nyc_geo_toolkit import centroids_from_boundaries, load_nyc_boundaries
+
+cbs = load_nyc_boundaries("community_district")
+centroid_collection = centroids_from_boundaries(cbs, representative=True)
+centroids = {
+    f.geography_value: (f.geometry["coordinates"][1], f.geometry["coordinates"][0])
+    for f in centroid_collection.features
+}
+```
+
 ## Questions
 
 Open an issue on [GitHub](https://github.com/random-walks/nyc311/issues). If you

--- a/docs/sdk.md
+++ b/docs/sdk.md
@@ -365,6 +365,35 @@ centroids = centroids_from_boundaries(boundaries)
 weights = build_distance_weights(centroids, threshold_meters=2000.0)
 ```
 
+!!! tip "Upstream shapely-backed centroids (nyc-geo-toolkit v0.4+)"
+
+    nyc311's `centroids_from_boundaries` returns the shapely-free
+    approximation (mean of exterior-ring points) as a
+    `dict[str, (lat, lon)]` so it feeds directly into
+    `build_distance_weights`. This is the lean default.
+
+    For publication-grade geometry — correct centroids, optional
+    `representative_point` for concave shorelines — use upstream's
+    shapely-backed helper (pulled in via
+    `pip install "nyc-geo-toolkit[spatial]"`):
+
+    ```python
+    from nyc_geo_toolkit import centroids_from_boundaries as ngt_centroids
+
+    centroid_collection = ngt_centroids(boundaries, representative=True)
+    centroids = {
+        f.geography_value: (
+            f.geometry["coordinates"][1],  # lat
+            f.geometry["coordinates"][0],  # lon
+        )
+        for f in centroid_collection.features
+    }
+    weights = build_distance_weights(centroids, threshold_meters=2000.0)
+    ```
+
+    The two helpers return **different shapes and different numbers**
+    — don't swap them mid-analysis.
+
 ## Statistical Modeling
 
 `nyc311.stats` is a thin, typed layer over `statsmodels`, `ruptures`,

--- a/examples/factor-factory-quickstart/README.md
+++ b/examples/factor-factory-quickstart/README.md
@@ -11,10 +11,32 @@ the reporting machinery, start here.
 
 - Build an nyc311 `PanelDataset` with a `TreatmentEvent`.
 - Convert via `PanelDataset.to_factor_factory_panel()`.
-- Fit `factor_factory.engines.did.estimate(panel, methods=("twfe",))`.
-- Print the ATT / SE / 95% CI / p-value as a pandas row.
+- Fit `factor_factory.engines.did.estimate(panel, methods=("twfe",))` twice:
+  - Once with `outcome="complaint_count"` (the volume signal).
+  - Once with `outcome="median_resolution_days"` (the resolution-latency
+    signal that `ServiceRequestRecord.closed_date` enables in v1.0.1+).
+- Print both ATT / SE / 95% CI / p-value rows as pandas DataFrames.
 
-Total: ~50 lines in `main.py`.
+Total: ~70 lines in `main.py`. Same panel, two engine fits — one
+`outcome=` swap.
+
+## What's also in the panel
+
+`PanelDataset.to_factor_factory_panel()` exposes every numeric column on the
+underlying `PanelObservation`s as a candidate outcome. The synthetic panel
+in this example carries:
+
+| Column                    | Notes                                                              |
+| ------------------------- | ------------------------------------------------------------------ |
+| `complaint_count`         | The default outcome (set via `outcome_col=`).                      |
+| `resolution_rate`         | Constant in the synthetic data; flat in DiD.                       |
+| `median_resolution_days`  | Drops 5 days post-treatment on the treated unit. DiD recovers it.  |
+| `treatment`               | `0/1` indicator — engine reads this for the DiD interaction.       |
+| `complaints_<type>`       | One per complaint type seen on the cell.                           |
+| `population`              | Per-unit population; useful for per-capita normalization.          |
+
+In a real run, `closed_date - created_date` would feed
+`median_resolution_days` for each cell at panel-build time.
 
 ## Running
 

--- a/examples/factor-factory-quickstart/main.py
+++ b/examples/factor-factory-quickstart/main.py
@@ -37,6 +37,10 @@ def build_synthetic_panel() -> PanelDataset:
         for i, p in enumerate(periods):
             is_treated = u == "MANHATTAN 03" and i >= 12
             count = int(50 + u_idx * 1.5 + i * 0.2 + (-5 if is_treated else 0))
+            # median_resolution_days drops 5 days post-treatment on the
+            # treated unit — gives the showcase a parallel resolution-time
+            # signal. (See §"What's also in the panel" in README.)
+            median_res = 7.0 + (-5.0 if is_treated else 0.0)
             rows.append(
                 PanelObservation(
                     unit_id=u,
@@ -44,7 +48,7 @@ def build_synthetic_panel() -> PanelDataset:
                     complaint_count=count,
                     complaint_counts_by_type={"Rodent": count},
                     resolution_rate=0.9,
-                    median_resolution_days=7.0,
+                    median_resolution_days=median_res,
                     treatment=is_treated,
                     treatment_date=date(2025, 1, 1) if u == "MANHATTAN 03" else None,
                     population=100_000,
@@ -68,12 +72,27 @@ def main() -> None:
     print("-- adapted to factor_factory.tidy.Panel --")
     print(f"   outcome_col={panel.outcome_col}, dimension={panel.dimension}")
 
-    print("-- fitting DiD (TWFE) --")
+    # Showcase 1: DiD on complaint volume.
+    print("-- fitting DiD (TWFE) on complaint_count --")
     results = did_estimate(panel, methods=("twfe",), outcome="complaint_count")
     df = pd.DataFrame([results[0].to_dict()])[
         ["method", "att", "se", "ci_95_lower", "ci_95_upper", "p_value", "n"]
     ]
     print(df.to_string(index=True))
+
+    # Showcase 2: same engine, different outcome column. The adapter
+    # exposes every numeric panel column to the engine — swap `outcome=`
+    # to pivot from volume to resolution latency without rebuilding the
+    # panel. This is the v1.0.1 closed_date / median_resolution_days
+    # workflow consumers were asking for.
+    print("\n-- fitting DiD (TWFE) on median_resolution_days --")
+    results_latency = did_estimate(
+        panel, methods=("twfe",), outcome="median_resolution_days"
+    )
+    df_latency = pd.DataFrame([results_latency[0].to_dict()])[
+        ["method", "att", "se", "ci_95_lower", "ci_95_upper", "p_value", "n"]
+    ]
+    print(df_latency.to_string(index=True))
 
 
 if __name__ == "__main__":

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,3 +66,4 @@ nav:
   - Contributing: contributing.md
   - Releasing: releasing.md
   - Changelog: changelog.md
+  - For LLMs / agents: llms.txt


### PR DESCRIPTION
## Summary

Post-release docs polish after v1.0.1 + v1.0.2 shipped this morning. No code change. Six identified gaps + one new file.

### New: `docs/llms.txt`

Canonical machine-readable [llmstxt.org](https://llmstxt.org)-style guide. ~75 lines covering:

- Project overview + ecosystem position
- Public surfaces (every module, with one-line summary each)
- Typical workflows (load/extract/aggregate, live Socrata, resolution-time, panel construction, factor-factory dispatch, tearsheets)
- Public contracts (`closed_date`, the two factor-factory bridges, with versioning rules)
- Install paths
- Tracked examples
- Version ranges (v1.0.2 state)
- Release history
- Ecosystem siblings

Wired into mkdocs nav as "For LLMs / agents". AGENTS.md gains a pointer at it. The intent is that an agent landing on the repo cold has a single short file that orients them — Cursor, Codex, Copilot, Claude Code, Aider, Zed, Windsurf, Gemini CLI, ChatGPT all consume `llms.txt` natively.

### Doc gaps caught from v1.0.1 + v1.0.2

| Gap | Fix |
|---|---|
| `docs/integration.md` pin row stale (`>=0.3.0,<0.4`) | → `>=0.3.0,<0.5`, heading bumped to "v1.0.2", inline note about the v1.0.2 widening |
| `docs/migration-v0-to-v1.md` had no v1.0.1 / v1.0.2 content | New "v1.0.1 + v1.0.2 addenda" section with before/after for `closed_date` (SDK-bypass → SDK) and shapely-backed centroids |
| `docs/sdk.md` "spatial weights" section silent on upstream centroids | Added `!!! tip` block pointing at `nyc_geo_toolkit.centroids_from_boundaries(..., representative=True)` with a complete adapter snippet that converts back to `dict[str, (lat, lon)]` for `build_distance_weights` |
| `AGENTS.md` had no per-release roll-up | New "Current release line" section listing v1.0.0, v1.0.1, v1.0.2 with one-line summaries |
| `README.md` missed v1.0.1 + v1.0.2 user-facing surface | New subsections under "factor-factory integration" — `closed_date` for resolution-time analysis + the centroids pin widening |

### Quickstart example pivot

`examples/factor-factory-quickstart/main.py` extended:

- Original: DiD on `complaint_count`, recovers ATT = -5.05 against true -5.0.
- Now also: DiD on `median_resolution_days` (pivots to the v1.0.1 closed_date / latency workflow). Same panel, single `outcome=` swap, recovers ATT = -5.00.

The quickstart README gains a "What's also in the panel" table documenting every numeric column the adapter exposes — addresses the implicit "what can I pivot to?" question consumers were asking.

## Files

```
A  docs/llms.txt                                 [new — 75 lines]
M  docs/integration.md                           [pin row fix]
M  docs/migration-v0-to-v1.md                    [new addenda section]
M  docs/sdk.md                                   [tip block]
M  README.md                                     [v1.0.1/v1.0.2 sub-sections]
M  AGENTS.md                                     [release-line section + llms.txt pointer]
M  mkdocs.yml                                    [nav entry for llms.txt]
M  examples/factor-factory-quickstart/main.py    [median_resolution_days fit]
M  examples/factor-factory-quickstart/README.md  [outcome-column table]
```

## Preflight

- ruff + ruff-format + mypy + public-API audit: clean
- prek hygiene hooks (prettier, blacken-docs, EOF, trailing-ws, codespell): idempotent locally
- mkdocs build --strict: clean (llms.txt resolves in nav)
- pytest -m "not integration": **234 passed**, 1 skipped, 2 documented xfails — no regressions
- factor-factory-quickstart end-to-end: both fits recover synthetic ATTs

## No release needed

Pure docs + example polish. Lands on `[Unreleased]` (which is empty as of v1.0.2). Next time we cut, this rolls into v1.0.3 or v1.1.0 alongside whatever code change drives the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)