### PR TITLE
docs(v1.0.3): surface upstream centroids_from_boundaries + CHANGELOG restructure (closes #24)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,86 @@
 
 ### Changed
 
+### Fixed
+
+### Deprecated
+
+### Contracts
+
+### Security
+
+## 1.0.3 - 2026-04-21
+
+Docs-only patch. Ships everything that landed on `main` after v1.0.2 (PR #23's
+llms.txt + doc refresh) plus a cross-reference surfacing
+`nyc_geo_toolkit.centroids_from_boundaries` from `nyc311.spatial` (closes
+[#24][i24]). No consumer code needs to change.
+
+### Added — machine-readable agent guide
+
+- **`docs/llms.txt`** — canonical [llmstxt.org](https://llmstxt.org)-style
+  summary consumed by Cursor, Codex, Copilot, Claude Code, Aider, Zed, Windsurf,
+  Gemini CLI, ChatGPT. Covers the public surface, typical workflows, contracts,
+  install paths, examples, version ranges, ecosystem siblings. Added to mkdocs
+  nav as "For LLMs / agents"; `AGENTS.md` gains a pointer at it.
+
+### Docs
+
+- **`nyc311.spatial` module + `load_boundaries_geodataframe` docstring** now
+  cross-reference upstream `nyc_geo_toolkit.centroids_from_boundaries` (v0.4+)
+  for polygon-centroid extraction (addresses [#24][i24] via the doc-only path —
+  nyc311 deliberately doesn't ship a centroid helper in `nyc311.spatial` because
+  the upstream helper is the one-stop shop).
+- **`docs/integration.md`** — new "Upstream helpers worth knowing" section with
+  the full `centroids_from_boundaries → build_distance_weights` composition
+  recipe inline, including the `(lat, lon)` vs `(lon, lat)` GeoJSON axis-flip.
+- **`docs/migration-v0-to-v1.md`** — new "v1.0.1 + v1.0.2 addenda" subsection
+  with before / after snippets for the `closed_date` SDK / Socrata-bypass
+  migration and the shapely-backed-centroid upgrade.
+- **`docs/sdk.md`** — `!!! tip` block in the spatial-weights section pointing at
+  upstream's shapely-backed helper with the complete `(lat, lon)` adapter
+  snippet for `build_distance_weights`.
+- **`docs/integration.md` pin row** refreshed to the v1.0.2 state
+  (`nyc-geo-toolkit>=0.3.0,<0.5`).
+- **`README.md`** — new v1.0.1 `closed_date` and v1.0.2 pin-widening subsections
+  under the existing factor-factory integration block.
+- **`AGENTS.md`** — new "Current release line" roll-up for v1.0.0 / v1.0.1 /
+  v1.0.2 / v1.0.3.
+- **`examples/factor-factory-quickstart/`** — extended to demonstrate both
+  `outcome="complaint_count"` and `outcome="median_resolution_days"` DiD fits
+  against the same panel (the v1.0.1 `closed_date` pivot workflow). Same panel,
+  single `outcome=` swap, two ATT recoveries. README gains a "What's also in the
+  panel" table documenting every numeric column the adapter exposes.
+
+### Ecosystem convergence
+
+Not code changes in this release, but worth tracking:
+
+- **`nyc-geo-toolkit` v0.4.1** (2026-04-21) — patch aligning the upstream
+  showcase with `jellycell.tearsheets` v1.4.0's native API. No public-surface
+  change. Our `>=0.3.0,<0.5` pin accepts it automatically.
+- **Jellycell v1.4.0** — landed upstream with the native `jellycell.tearsheets`
+  API ([#24][j24]) and deps-comma lint fix ([#25][j25]). All six issues we filed
+  from v1.0.0 dogfooding (J1 through J6) are closed. Our `jellycell>=1.3.5,<2`
+  pin accepts v1.4.0 via semver when it hits PyPI. A targeted alignment pass —
+  dropping `factor_factory.jellycell.cells.setup()` workarounds in favour of the
+  native API — is a future concern gated on factor-factory's own update cycle.
+- Three downstream follow-ups filed: [nyc311#24][i24] (this release),
+  [subway-access#19 comment](https://github.com/random-walks/subway-access/pull/19),
+  [blaise-website#20](https://github.com/random-walks/blaise-website/issues/20)
+  (resolution-equity centroid swap).
+
+[i24]: https://github.com/random-walks/nyc311/issues/24
+[j24]: https://github.com/random-walks/jellycell/issues/24
+[j25]: https://github.com/random-walks/jellycell/issues/25
+
+## 1.0.2 - 2026-04-20
+
+Patch release. Widens the `nyc-geo-toolkit` pin so consumers can pick up
+upstream v0.4.0 (shapely-backed `centroids_from_boundaries`) alongside nyc311.
+
+### Changed
+
 - **Widen the `nyc-geo-toolkit` pin** from `>=0.3.0,<0.4` to `>=0.3.0,<0.5` so
   consumers can pick up the just-shipped [nyc-geo-toolkit v0.4.0][ngt040]
   alongside nyc311. The upstream v0.4.0 release adds a shapely-backed
@@ -18,14 +98,6 @@
 
 [ngt040]: https://github.com/random-walks/nyc-geo-toolkit/releases/tag/v0.4.0
 [ngt12]: https://github.com/random-walks/nyc-geo-toolkit/issues/12
-
-### Fixed
-
-### Deprecated
-
-### Contracts
-
-### Security
 
 ## 1.0.1 - 2026-04-20
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -151,6 +151,41 @@ Each case study ships a `jellycell.toml` alongside its `run_analysis.py` so
 | `nyc-geo-toolkit` | `>=0.3.0,<0.5` (widened v1.0.2 for upstream v0.4) |
 | Python            | `>=3.12` (dropped 3.10/3.11 in v1.0.0)            |
 
+## Upstream helpers worth knowing
+
+These live in `nyc-geo-toolkit` and `factor-factory` but compose naturally with
+`nyc311.spatial` / `nyc311.temporal` workflows:
+
+- **`nyc_geo_toolkit.centroids_from_boundaries(boundaries, *, representative=False)`**
+  — v0.4+. Turns any polygon `BoundaryCollection` into a Point
+  `BoundaryCollection`. For spatial weights, Moran's I / LISA, nearest-neighbour
+  joins, choropleth label placement. Use `representative=True` for concave NYC
+  shorelines.
+
+  ```python
+  from nyc_geo_toolkit import centroids_from_boundaries, load_nyc_boundaries
+  from nyc311.temporal import build_distance_weights
+
+  cbs = load_nyc_boundaries("community_district")
+  point_collection = centroids_from_boundaries(cbs, representative=True)
+  # Flip (lon, lat) GeoJSON order to (lat, lon) for build_distance_weights.
+  unit_centroids = {
+      f.geography_value: (f.geometry["coordinates"][1], f.geometry["coordinates"][0])
+      for f in point_collection.features
+  }
+  weights = build_distance_weights(unit_centroids, threshold_meters=2000.0)
+  ```
+
+  nyc311 v1.0.2+ (pin `>=0.3.0,<0.5`) allows installing the required
+  nyc-geo-toolkit version. Install with the `[spatial]` extra upstream for the
+  shapely dependency.
+
+- **`factor_factory.engines.*.estimate(panel, ...)`** — the engine families
+  listed above. Call via `Pipeline.as_factor_factory_estimate()` for the
+  chaining convenience, or import directly.
+
+## factor-factory roadmap
+
 Follow the
 [factor-factory roadmap](https://github.com/random-walks/factor-factory/blob/main/docs/og_context/06_post_v0.1_roadmap.md)
 for upcoming engine families; most new engines become available to

--- a/src/nyc311/spatial/__init__.py
+++ b/src/nyc311/spatial/__init__.py
@@ -1,4 +1,36 @@
-"""Optional geospatial helpers built on top of the typed nyc311 models."""
+"""Optional geospatial helpers built on top of the typed nyc311 models.
+
+The `nyc311.spatial` module is the GeoDataFrame-flavoured sibling of
+`nyc311.geographies` — it loads boundary layers and records as
+geopandas frames, spatially joins records to boundaries, and
+materialises typed summaries as map-ready GeoDataFrames.
+
+.. note::
+
+   For **polygon-centroid points** (distance-band spatial weights,
+   Moran's *I* / LISA, nearest-neighbour joins, choropleth label
+   placement), nyc311 deliberately does **not** ship a centroid
+   helper in this module. Use upstream instead:
+
+   .. code-block:: python
+
+       from nyc_geo_toolkit import (
+           centroids_from_boundaries,
+           load_nyc_boundaries,
+       )
+
+       cbs = load_nyc_boundaries("community_district")
+       # representative=True keeps the point inside the polygon —
+       # matters for non-convex NYC shorelines.
+       points = centroids_from_boundaries(cbs, representative=True)
+
+   Shipped as a first-class helper in nyc-geo-toolkit v0.4.0 (on
+   PyPI as v0.4.1 since 2026-04-21). Requires the ``[spatial]``
+   extra on nyc-geo-toolkit for the shapely dependency. See also
+   :func:`nyc311.temporal.centroids_from_boundaries`, which returns
+   a shapely-free ``dict[str, (lat, lon)]`` suitable for direct
+   use with :func:`nyc311.temporal.build_distance_weights`.
+"""
 
 from __future__ import annotations
 

--- a/src/nyc311/spatial/_boundaries.py
+++ b/src/nyc311/spatial/_boundaries.py
@@ -20,7 +20,17 @@ def load_boundaries_geodataframe(
     *,
     layer: str | None = None,
 ) -> Any:
-    """Load supported boundaries from a path, collection, or packaged layer."""
+    """Load supported boundaries from a path, collection, or packaged layer.
+
+    .. note::
+
+       Need polygon centroids for spatial weights / Moran's I / label
+       placement? Upstream :func:`nyc_geo_toolkit.centroids_from_boundaries`
+       (v0.4+) converts any polygon ``BoundaryCollection`` into a Point
+       ``BoundaryCollection``, preserving geography / vintage / properties.
+       Pair with ``representative=True`` for non-convex polygons. See the
+       :mod:`nyc311.spatial` module docstring for the full recipe.
+    """
     if layer is not None:
         if source is not None:
             raise ValueError("Pass either source or layer, not both.")


### PR DESCRIPTION
## Summary

Closes [#24](https://github.com/random-walks/nyc311/issues/24) via the doc-only path (Option B from the issue discussion) and restructures the CHANGELOG to accurately reflect what shipped in v1.0.2 vs what's landing as v1.0.3.

## What changes

### 1. #24 — surface `nyc_geo_toolkit.centroids_from_boundaries`

- `src/nyc311/spatial/__init__.py` — module docstring expanded with a `.. note::` block pointing at `nyc_geo_toolkit.centroids_from_boundaries` (v0.4+), with a complete recipe inline (including the `representative=True` flag for non-convex NYC shorelines).
- `src/nyc311/spatial/_boundaries.py` — `load_boundaries_geodataframe` docstring gains a `.. note::` sibling pointing at the same helper.
- `docs/integration.md` — new "Upstream helpers worth knowing" section with the full `centroids_from_boundaries → build_distance_weights` composition recipe, including the `(lat, lon)` vs `(lon, lat)` GeoJSON axis-flip gotcha.

**Deliberately no `nyc311.spatial` re-export shim.** Option A from the issue is deferred; upstream's helper is the one-stop shop and adding a nyc311 wrapper would split the ecosystem API surface for zero benefit. If that calculus changes later, a v1.1.0 can add the re-export.

### 2. CHANGELOG restructure

The `[Unreleased]` section was carrying content that should have been under v1.0.2. Fixed:

- **New `## 1.0.2 - 2026-04-20`** — backfilled with the nyc-geo-toolkit pin-widen bullet (was orphaned under Unreleased until now).
- **New `## 1.0.3 - 2026-04-21`** — collects everything that landed on `main` after v1.0.2:
  - PR #23's docs polish: `llms.txt`, migration addenda, `docs/sdk.md` tip block, README subsections, `AGENTS.md` release-line roll-up, quickstart pivot demonstrating `outcome="median_resolution_days"`.
  - This PR's #24 cross-reference.
- `[Unreleased]` is now empty with the usual Added / Changed / Fixed / Deprecated / Contracts / Security scaffold.

### 3. Ecosystem-convergence subsection

The v1.0.3 entry includes a short "Ecosystem convergence" note capturing:

- **nyc-geo-toolkit v0.4.1** (2026-04-21) — patch aligning the upstream showcase with jellycell v1.4.0. Our pin accepts it automatically.
- **Jellycell v1.4.0** — all six issues we filed from v1.0.0 dogfooding closed upstream. Alignment pass gated on factor-factory's own update cycle.
- Three downstream follow-ups filed (nyc311#24, subway-access#19, blaise-website#20).

Pure bookkeeping — no user needs to act on it, but the historical record matters for release-auditor chains.

## Why patch bump

Per `.claude/skills/release-bump.md`: docs-only changes are patch-level. No new public API, no signature change, no dep pin movement. Adding the `centroids_from_boundaries` re-export would be a minor bump (new public name in `__all__`) — deferred.

## Preflight

- ruff + ruff-format + mypy + public-API audit: clean
- prek hygiene hooks (prettier, blacken-docs, EOF, trailing-ws, codespell): **idempotent** locally
- `mkdocs build --strict`: clean (both cross-references resolve)
- `pytest -m "not integration"`: **234 passed**, 1 skipped, 2 documented xfails — no regressions

## Ship path

- Merge this PR on green
- Tag `v1.0.3` on the merge commit
- CD workflow publishes to PyPI via OIDC

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)